### PR TITLE
Add DTO model, API client, and NUnit tests for API-QC-POST-001

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class ApiResponse<T>
+{
+    public T Data { get; set; }
+    public int StatusCode { get; set; }
+    public string ErrorMessage { get; set; }
+}
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+    private bool _simulateError;
+
+    public QuickCommentApiClient(string baseUrl)
+    {
+        _httpClient = new HttpClient();
+        _baseUrl = baseUrl;
+    }
+
+    public void SimulateError(bool simulate)
+    {
+        _simulateError = simulate;
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        if (_simulateError)
+        {
+            return new ApiResponse<List<QuickCommentDto>>
+            {
+                StatusCode = 500,
+                ErrorMessage = "Simulated internal server error"
+            };
+        }
+
+        var response = await _httpClient.PostAsync($"{_baseUrl}/api/v1/QuickComments?quickCommentCategory={(int)category}", null);
+
+        var apiResponse = new ApiResponse<List<QuickCommentDto>>
+        {
+            StatusCode = (int)response.StatusCode
+        };
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            apiResponse.Data = JsonSerializer.Deserialize<List<QuickCommentDto>>(content);
+        }
+        else
+        {
+            apiResponse.ErrorMessage = await response.Content.ReadAsStringAsync();
+        }
+
+        return apiResponse;
+    }
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,19 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceOfDonation = 2,
+    Other = 3
+}
+
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}
+
+public class ContentResult
+{
+    public string Content { get; set; }
+    public string ContentType { get; set; }
+    public int? StatusCode { get; set; }
+}

--- a/Tests/QuickCommentTests.cs
+++ b/Tests/QuickCommentTests.cs
@@ -1,0 +1,69 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+[TestFixture]
+public class QuickCommentTests
+{
+    private QuickCommentApiClient _apiClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        _apiClient = new QuickCommentApiClient("https://api.example.com");
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsOkWithComments()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _apiClient.GetQuickCommentsAsync(category);
+
+        // Assert
+        Assert.AreEqual(200, response.StatusCode);
+        Assert.IsNotNull(response.Data);
+        Assert.IsInstanceOf<List<QuickCommentDto>>(response.Data);
+        Assert.IsTrue(response.Data.Count > 0);
+
+        foreach (var comment in response.Data)
+        {
+            Assert.IsInstanceOf<int>(comment.Id);
+            Assert.IsInstanceOf<string>(comment.Comment);
+        }
+    }
+
+    [Test]
+    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
+    {
+        // Arrange
+        var category = (QuickCommentCategory)999; // Invalid category
+
+        // Act
+        var response = await _apiClient.GetQuickCommentsAsync(category);
+
+        // Assert
+        Assert.AreEqual(400, response.StatusCode);
+        Assert.IsNull(response.Data);
+        Assert.IsNotNull(response.ErrorMessage);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ServerError_ReturnsInternalServerError()
+    {
+        // Arrange
+        _apiClient.SimulateError(true);
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _apiClient.GetQuickCommentsAsync(category);
+
+        // Assert
+        Assert.AreEqual(500, response.StatusCode);
+        Assert.IsNull(response.Data);
+        Assert.IsNotNull(response.ErrorMessage);
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added DTO model for QuickCommentDto and related classes.
- Implemented QuickCommentApiClient for interacting with the /api/v1/QuickComments endpoint.
- Created NUnit tests to verify the functionality of the QuickCommentApiClient.

Files added:
- Models/QuickCommentDto.cs
- Clients/QuickCommentApiClient.cs
- Tests/QuickCommentTests.cs

Test Case ID: API-QC-POST-001
Test Case Summary: Verify that the /api/v1/QuickComments endpoint returns a collection of QuickComments for a valid quickCommentCategory.