### PR TITLE
Add C# autotests for Postman collection for QuickComments endpoint

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class ApiResponse<T>
+{
+    public T Data { get; set; }
+    public int StatusCode { get; set; }
+    public string ErrorMessage { get; set; }
+}
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+    private bool _simulateError;
+
+    public QuickCommentApiClient(string baseUrl)
+    {
+        _httpClient = new HttpClient();
+        _baseUrl = baseUrl;
+    }
+
+    public void SimulateError(bool simulate)
+    {
+        _simulateError = simulate;
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        if (_simulateError)
+        {
+            return new ApiResponse<List<QuickCommentDto>>
+            {
+                StatusCode = 500,
+                ErrorMessage = "Simulated server error"
+            };
+        }
+
+        var response = await _httpClient.PostAsync($"{_baseUrl}/api/v1/QuickComments?quickCommentCategory={(int)category}", null);
+
+        var apiResponse = new ApiResponse<List<QuickCommentDto>>
+        {
+            StatusCode = (int)response.StatusCode
+        };
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            apiResponse.Data = JsonSerializer.Deserialize<List<QuickCommentDto>>(content);
+        }
+        else
+        {
+            apiResponse.ErrorMessage = await response.Content.ReadAsStringAsync();
+        }
+
+        return apiResponse;
+    }
+}

--- a/Models/QuickCommentModels.cs
+++ b/Models/QuickCommentModels.cs
@@ -1,0 +1,18 @@
+public enum QuickCommentCategory
+{
+    ReasonsForCancellation = 1,
+    ExperienceOfDonation = 2
+}
+
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}
+
+public class ContentResult
+{
+    public string Content { get; set; }
+    public string ContentType { get; set; }
+    public int? StatusCode { get; set; }
+}

--- a/Tests/QuickCommentTests.cs
+++ b/Tests/QuickCommentTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+[TestFixture]
+public class QuickCommentTests
+{
+    private QuickCommentApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        _client = new QuickCommentApiClient("http://api.example.com");
+    }
+
+    [Test]
+    public async Task GetQuickComments_SuccessfulRequest_ReturnsOkWithData()
+    {
+        var response = await _client.GetQuickCommentsAsync(QuickCommentCategory.ReasonsForCancellation);
+
+        Assert.AreEqual(200, response.StatusCode);
+        Assert.IsNotNull(response.Data);
+        Assert.IsInstanceOf<List<QuickCommentDto>>(response.Data);
+    }
+
+    [Test]
+    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
+    {
+        _client.SimulateError(true);
+        var response = await _client.GetQuickCommentsAsync((QuickCommentCategory)999);
+
+        Assert.AreEqual(400, response.StatusCode);
+        Assert.IsNull(response.Data);
+        Assert.IsNotNull(response.ErrorMessage);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ServerError_ReturnsInternalServerError()
+    {
+        _client.SimulateError(true);
+        var response = await _client.GetQuickCommentsAsync(QuickCommentCategory.ExperienceOfDonation);
+
+        Assert.AreEqual(500, response.StatusCode);
+        Assert.IsNull(response.Data);
+        Assert.IsNotNull(response.ErrorMessage);
+    }
+}


### PR DESCRIPTION
This pull request includes the following files:

- Models/QuickCommentModels.cs: Contains the DTO models for QuickCommentCategory, QuickCommentDto, and ContentResult.
- Clients/QuickCommentApiClient.cs: Contains the API client for the QuickComments endpoint.
- Tests/QuickCommentTests.cs: Contains the NUnit tests for the QuickComments endpoint.

These files were generated to cover the Swagger JSON fragment and test scenario provided.