### PR TITLE
Add API client and tests for API-POST-Firebase-001

### DIFF
--- a/Clients/FirebaseApiClient.cs
+++ b/Clients/FirebaseApiClient.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Text.Json;
+
+public class FirebaseApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public FirebaseApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<ContentResult>> SavePushTokenAsync(string deviceId, string token)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/Firebase?deviceId={Uri.EscapeDataString(deviceId)}&token={Uri.EscapeDataString(token)}", null);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var contentResult = JsonSerializer.Deserialize<ContentResult>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        return new ApiResponse<ContentResult>
+        {
+            StatusCode = (int)response.StatusCode,
+            Data = contentResult
+        };
+    }
+}
+
+public class ApiResponse<T>
+{
+    public int StatusCode { get; set; }
+    public T Data { get; set; }
+}

--- a/Tests/ApiPostFirebase001Tests.cs
+++ b/Tests/ApiPostFirebase001Tests.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class ApiPostFirebase001Tests
+{
+    private FirebaseApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _client = new FirebaseApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task SavePushToken_WithValidData_ShouldReturnSuccessResponse()
+    {
+        // Arrange
+        string deviceId = "12345-abcde";
+        string token = "validPushToken123";
+
+        // Act
+        var response = await _client.SavePushTokenAsync(deviceId, token);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Content.Should().Be("PushToken was saved successfully");
+        response.Data.ContentType.Should().Be("application/json");
+        response.Data.StatusCode.Should().Be(200);
+    }
+
+    [Test]
+    public async Task SavePushToken_WithInvalidData_ShouldReturnBadRequestResponse()
+    {
+        // Arrange
+        string deviceId = "";
+        string token = "";
+
+        // Act
+        var response = await _client.SavePushTokenAsync(deviceId, token);
+
+        // Assert
+        response.StatusCode.Should().Be(400);
+        response.Data.Should().NotBeNull();
+        response.Data.Content.Should().Contain("Bad request");
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        // Add any necessary cleanup code here
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added FirebaseApiClient.cs in Clients directory to handle the /api/v1/Firebase endpoint.
- Added ApiPostFirebase001Tests.cs in Tests directory to cover the test scenario for saving PushToken.

Test Case ID: API-POST-Firebase-001
Test Summary: Verify that the PushToken is saved successfully when valid `deviceId` and `token` are provided.

Files involved:
- Clients/FirebaseApiClient.cs
- Tests/ApiPostFirebase001Tests.cs