### PR TITLE
Add DTO model, API client, and NUnit tests for DT-001: Verify successful retrieval of all donation types using the GET method.

### DIFF
--- a/Clients/DonationTypesApiClient.cs
+++ b/Clients/DonationTypesApiClient.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+public class DonationTypesApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public DonationTypesApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<List<DonationTypeDto>>> GetDonationTypesAsync()
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync("/api/v1/donation/types");
+            response.EnsureSuccessStatusCode();
+            var donationTypes = await response.Content.ReadFromJsonAsync<List<DonationTypeDto>>();
+            return new ApiResponse<List<DonationTypeDto>>(donationTypes, (int)response.StatusCode);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new ApiResponse<List<DonationTypeDto>>(null, 500, ex.Message);
+        }
+    }
+
+    public async Task<ApiResponse<ContentResult>> AddDonationTypeAsync(DonationTypeDto donationType)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync("/api/v1/donation/types", donationType);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadFromJsonAsync<ContentResult>();
+            return new ApiResponse<ContentResult>(content, (int)response.StatusCode);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new ApiResponse<ContentResult>(null, 500, ex.Message);
+        }
+    }
+
+    public async Task<ApiResponse<ContentResult>> EditDonationTypeAsync(DonationTypeDto donationType)
+    {
+        try
+        {
+            var response = await _httpClient.PutAsJsonAsync("/api/v1/donation/types", donationType);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadFromJsonAsync<ContentResult>();
+            return new ApiResponse<ContentResult>(content, (int)response.StatusCode);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new ApiResponse<ContentResult>(null, 500, ex.Message);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public T Data { get; }
+    public int StatusCode { get; }
+    public string ErrorMessage { get; }
+
+    public ApiResponse(T data, int statusCode, string errorMessage = null)
+    {
+        Data = data;
+        StatusCode = statusCode;
+        ErrorMessage = errorMessage;
+    }
+}

--- a/Models/DonationTypeDto.cs
+++ b/Models/DonationTypeDto.cs
@@ -1,0 +1,5 @@
+public class DonationTypeDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}

--- a/Tests/DT001Tests.cs
+++ b/Tests/DT001Tests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using System.Collections.Generic;
+
+[TestFixture]
+public class DT001Tests
+{
+    private DonationTypesApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _client = new DonationTypesApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task GetDonationTypes_ShouldReturnSuccessfulResponse()
+    {
+        // Arrange
+        // No additional arrangement needed as we're testing the GET endpoint
+
+        // Act
+        var response = await _client.GetDonationTypesAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().NotBeEmpty();
+
+        foreach (var donationType in response.Data)
+        {
+            donationType.Should().NotBeNull();
+            donationType.Id.Should().BeGreaterThan(0);
+            donationType.Name.Should().NotBeNullOrEmpty();
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added `DonationTypeDto` model in `Models/DonationTypeDto.cs`
- Added `DonationTypesApiClient` in `Clients/DonationTypesApiClient.cs` with methods for GET, POST, and PUT endpoints
- Added NUnit test class `DT001Tests` in `Tests/DT001Tests.cs` to verify the retrieval of donation types

These changes cover the test scenario described in DT-001, ensuring that the GET method for `/api/v1/donation/types` works as expected.

Files involved:
- `Models/DonationTypeDto.cs`
- `Clients/DonationTypesApiClient.cs`
- `Tests/DT001Tests.cs`