### PR TITLE
Add DTO model, API client, and tests for API-POST-DONATION-TYPES-001

### DIFF
--- a/Clients/DonationTypesApiClient.cs
+++ b/Clients/DonationTypesApiClient.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using DonorApp.Services.DTO;
+
+namespace DonorApp.ApiClient
+{
+    public class DonationTypesApiClient
+    {
+        private readonly HttpClient _httpClient;
+        private readonly string _baseUrl;
+
+        public DonationTypesApiClient(HttpClient httpClient, string baseUrl)
+        {
+            _httpClient = httpClient;
+            _baseUrl = baseUrl;
+        }
+
+        public async Task<ApiResponse<ContentResult>> AddDonationTypeAsync(DonationTypeDto donationTypeDto)
+        {
+            var url = $"{_baseUrl}/api/v1/donation/types";
+            var content = new StringContent(JsonConvert.SerializeObject(donationTypeDto), Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync(url, content);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            return new ApiResponse<ContentResult>
+            {
+                StatusCode = (int)response.StatusCode,
+                Data = JsonConvert.DeserializeObject<ContentResult>(responseContent)
+            };
+        }
+    }
+
+    public class ApiResponse<T>
+    {
+        public int StatusCode { get; set; }
+        public T Data { get; set; }
+    }
+}

--- a/Models/DonationTypeDto.cs
+++ b/Models/DonationTypeDto.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace DonorApp.Services.DTO
+{
+    public class DonationTypeDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string ShortDescription { get; set; }
+        public string LongDescription { get; set; }
+        public string IconData { get; set; }
+        public DateTime CreateDate { get; set; }
+        public string CreatedBy { get; set; }
+        public DateTime UpdateDate { get; set; }
+        public string LastUpdatedBy { get; set; }
+        public string HeaderColor { get; set; }
+    }
+}

--- a/Tests/ApiPostDonationTypes001Tests.cs
+++ b/Tests/ApiPostDonationTypes001Tests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using FluentAssertions;
+using DonorApp.ApiClient;
+using DonorApp.Services.DTO;
+
+namespace DonorApp.Tests
+{
+    [TestFixture]
+    public class ApiPostDonationTypes001Tests
+    {
+        private DonationTypesApiClient _client;
+        private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+        [SetUp]
+        public void Setup()
+        {
+            var httpClient = new HttpClient();
+            _client = new DonationTypesApiClient(httpClient, BaseUrl);
+        }
+
+        [Test]
+        public async Task AddDonationType_ValidData_ReturnsSuccessfulResponse()
+        {
+            // Arrange
+            var newDonationType = new DonationTypeDto
+            {
+                Name = "Test Donation Type",
+                ShortDescription = "Short description",
+                LongDescription = "Long description",
+                IconData = "base64encodedicon",
+                CreateDate = DateTime.UtcNow,
+                CreatedBy = "TestUser",
+                UpdateDate = DateTime.UtcNow,
+                LastUpdatedBy = "TestUser",
+                HeaderColor = "#FF0000"
+            };
+
+            // Act
+            var response = await _client.AddDonationTypeAsync(newDonationType);
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+            response.Data.Should().NotBeNull();
+            response.Data.Content.Should().NotBeNullOrEmpty();
+            response.Data.StatusCode.Should().Be(200);
+        }
+
+        [Test]
+        public async Task AddDonationType_InvalidData_ReturnsBadRequest()
+        {
+            // Arrange
+            var invalidDonationType = new DonationTypeDto
+            {
+                // Missing required fields
+            };
+
+            // Act
+            var response = await _client.AddDonationTypeAsync(invalidDonationType);
+
+            // Assert
+            response.StatusCode.Should().Be(400);
+            response.Data.Should().NotBeNull();
+            response.Data.Content.Should().NotBeNullOrEmpty();
+            response.Data.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public async Task AddDonationType_ServerError_ReturnsInternalServerError()
+        {
+            // Arrange
+            var donationType = new DonationTypeDto
+            {
+                Name = "Server Error Test",
+                ShortDescription = "This should trigger a server error",
+                // Add other required fields
+            };
+
+            // Act
+            var response = await _client.AddDonationTypeAsync(donationType);
+
+            // Assert
+            response.StatusCode.Should().Be(500);
+            response.Data.Should().NotBeNull();
+            response.Data.Content.Should().NotBeNullOrEmpty();
+            response.Data.StatusCode.Should().Be(500);
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added `DonationTypeDto` model in `Models/DonationTypeDto.cs`
- Created `DonationTypesApiClient` in `Clients/DonationTypesApiClient.cs` to handle the `/api/v1/donation/types` endpoint
- Added NUnit tests in `Tests/ApiPostDonationTypes001Tests.cs` to verify the functionality of the `/api/v1/donation/types` endpoint

These changes are based on the provided Swagger JSON fragment and test scenario for API-POST-DONATION-TYPES-001.