### PR TITLE
Add C# autotests for API-QC-001: Verify that the /api/v1/QuickComments endpoint returns a collection of QuickComments

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public QuickCommentApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={(int)category}", null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            var quickComments = JsonSerializer.Deserialize<List<QuickCommentDto>>(content, _jsonOptions);
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, quickComments);
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            var errorResult = JsonSerializer.Deserialize<ContentResult>(errorContent, _jsonOptions);
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, null, errorResult);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public T Data { get; }
+    public ContentResult ErrorResult { get; }
+
+    public ApiResponse(System.Net.HttpStatusCode statusCode, T data, ContentResult errorResult = null)
+    {
+        StatusCode = statusCode;
+        Data = data;
+        ErrorResult = errorResult;
+    }
+}

--- a/Models/QuickCommentCategoryEnum.cs
+++ b/Models/QuickCommentCategoryEnum.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceComment = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string? Comment { get; set; }
+}

--- a/Tests/ApiQc001Tests.cs
+++ b/Tests/ApiQc001Tests.cs
@@ -1,0 +1,68 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using System.Net;
+using System.Collections.Generic;
+
+[TestFixture]
+public class ApiQc001Tests
+{
+    private HttpClient _httpClient;
+    private QuickCommentApiClient _apiClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        _httpClient = new HttpClient
+        {
+            BaseAddress = new System.Uri("https://api-base-url.com") // Replace with actual base URL
+        };
+        _apiClient = new QuickCommentApiClient(_httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsQuickComments()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _apiClient.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeAssignableTo<List<QuickCommentDto>>();
+
+        foreach (var quickComment in response.Data)
+        {
+            quickComment.Id.Should().BeGreaterThan(0);
+            quickComment.Comment.Should().NotBeNull().When(comment => comment != null);
+        }
+
+        _httpClient.DefaultRequestHeaders.Accept
+            .Should().Contain(header => header.MediaType == "application/json");
+    }
+
+    [Test]
+    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
+    {
+        // Arrange
+        var invalidCategory = (QuickCommentCategory)999; // Invalid category
+
+        // Act
+        var response = await _apiClient.GetQuickCommentsAsync(invalidCategory);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.ErrorResult.Should().NotBeNull();
+        response.ErrorResult.StatusCode.Should().Be(400);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _httpClient.Dispose();
+    }
+}


### PR DESCRIPTION
This pull request includes the following files:

- Models/QuickCommentCategoryEnum.cs
- Models/QuickCommentDto.cs
- Clients/QuickCommentApiClient.cs
- Tests/ApiQc001Tests.cs

These files cover the requirements specified in the Swagger JSON fragment and the test scenario. The DTO models are created for the missing schemas, the API client includes a method to call the /api/v1/QuickComments endpoint, and the NUnit test file implements the scenario steps, including positive and negative test cases.