### PR TITLE
Add C# autotests for API-FAQS-CATEGORY-POST-PUT

### DIFF
--- a/Clients/FaqCategoryApiClient.cs
+++ b/Clients/FaqCategoryApiClient.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class FaqCategoryApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public FaqCategoryApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<FaqCategoryDto>> AddFaqCategoryAsync(FaqCategoryDto faqCategory)
+    {
+        var json = JsonConvert.SerializeObject(faqCategory);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PostAsync("/api/v1/faqs/category", content);
+        return await CreateApiResponseAsync<FaqCategoryDto>(response);
+    }
+
+    public async Task<ApiResponse<FaqCategoryDto>> EditFaqCategoryAsync(FaqCategoryDto faqCategory)
+    {
+        var json = JsonConvert.SerializeObject(faqCategory);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PutAsync("/api/v1/faqs/category", content);
+        return await CreateApiResponseAsync<FaqCategoryDto>(response);
+    }
+
+    private async Task<ApiResponse<T>> CreateApiResponseAsync<T>(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        var apiResponse = new ApiResponse<T>
+        {
+            StatusCode = (int)response.StatusCode,
+            IsSuccessStatusCode = response.IsSuccessStatusCode
+        };
+
+        if (response.IsSuccessStatusCode)
+        {
+            apiResponse.Data = JsonConvert.DeserializeObject<T>(content);
+        }
+        else
+        {
+            apiResponse.ErrorContent = JsonConvert.DeserializeObject<ContentResult>(content);
+        }
+
+        return apiResponse;
+    }
+}
+
+public class ApiResponse<T>
+{
+    public int StatusCode { get; set; }
+    public bool IsSuccessStatusCode { get; set; }
+    public T Data { get; set; }
+    public ContentResult ErrorContent { get; set; }
+}

--- a/Models/FaqCategoryDto.cs
+++ b/Models/FaqCategoryDto.cs
@@ -1,0 +1,6 @@
+public class FaqCategoryDto
+{
+    public long Id { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+}

--- a/Tests/ApiFaqsCategoryPostPutTests.cs
+++ b/Tests/ApiFaqsCategoryPostPutTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class ApiFaqsCategoryPostPutTests
+{
+    private FaqCategoryApiClient _apiClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _apiClient = new FaqCategoryApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task API_FAQS_CATEGORY_POST_PUT_Test()
+    {
+        // Step 1: Send a POST request to /api/v1/faqs/category with a valid FaqCategoryDto payload.
+        var newCategory = new FaqCategoryDto
+        {
+            Name = "Test Category",
+            Description = "This is a test category"
+        };
+
+        var postResponse = await _apiClient.AddFaqCategoryAsync(newCategory);
+
+        // Step 2: Verify the response status is 200 and the response body matches the FaqCategoryDto schema.
+        postResponse.StatusCode.Should().Be(200);
+        postResponse.IsSuccessStatusCode.Should().BeTrue();
+        postResponse.Data.Should().NotBeNull();
+        postResponse.Data.Id.Should().BeGreaterThan(0);
+        postResponse.Data.Name.Should().Be(newCategory.Name);
+        postResponse.Data.Description.Should().Be(newCategory.Description);
+
+        // Step 3: Send a PUT request to /api/v1/faqs/category with a valid FaqCategoryDto payload.
+        var updatedCategory = new FaqCategoryDto
+        {
+            Id = postResponse.Data.Id,
+            Name = "Updated Test Category",
+            Description = "This is an updated test category"
+        };
+
+        var putResponse = await _apiClient.EditFaqCategoryAsync(updatedCategory);
+
+        // Step 4: Verify the response status is 200 and the response body matches the FaqCategoryDto schema.
+        putResponse.StatusCode.Should().Be(200);
+        putResponse.IsSuccessStatusCode.Should().BeTrue();
+        putResponse.Data.Should().NotBeNull();
+        putResponse.Data.Id.Should().Be(updatedCategory.Id);
+        putResponse.Data.Name.Should().Be(updatedCategory.Name);
+        putResponse.Data.Description.Should().Be(updatedCategory.Description);
+    }
+}


### PR DESCRIPTION
Implemented DTO model, API client, and NUnit tests for the /api/v1/faqs/category endpoint supporting POST and PUT methods for adding and editing FAQ categories.

Files added:
- Models/FaqCategoryDto.cs
- Clients/FaqCategoryApiClient.cs
- Tests/ApiFaqsCategoryPostPutTests.cs