### PR TITLE
Add DTO model, API client, and NUnit tests for API_FAQS_CATEGORY_POST_PUT

### DIFF
--- a/Clients/FaqCategoryApiClient.cs
+++ b/Clients/FaqCategoryApiClient.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using YourNamespace.Models;
+
+namespace YourNamespace.ApiClients
+{
+    public class FaqCategoryApiClient
+    {
+        private readonly HttpClient _httpClient;
+        private const string BaseUrl = "https://your-api-base-url.com"; // Replace with your actual base URL
+
+        public FaqCategoryApiClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+            _httpClient.BaseAddress = new Uri(BaseUrl);
+        }
+
+        public async Task<ApiResponse<FaqCategoryDto>> AddFaqCategoryAsync(FaqCategoryDto faqCategory)
+        {
+            var json = JsonConvert.SerializeObject(faqCategory);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync("/api/v1/faqs/category", content);
+            return await ProcessResponseAsync<FaqCategoryDto>(response);
+        }
+
+        public async Task<ApiResponse<FaqCategoryDto>> EditFaqCategoryAsync(FaqCategoryDto faqCategory)
+        {
+            var json = JsonConvert.SerializeObject(faqCategory);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PutAsync("/api/v1/faqs/category", content);
+            return await ProcessResponseAsync<FaqCategoryDto>(response);
+        }
+
+        private async Task<ApiResponse<T>> ProcessResponseAsync<T>(HttpResponseMessage response)
+        {
+            var apiResponse = new ApiResponse<T>
+            {
+                StatusCode = (int)response.StatusCode,
+                IsSuccessStatusCode = response.IsSuccessStatusCode
+            };
+
+            var content = await response.Content.ReadAsStringAsync();
+
+            if (response.IsSuccessStatusCode)
+            {
+                apiResponse.Data = JsonConvert.DeserializeObject<T>(content);
+            }
+            else
+            {
+                apiResponse.Error = JsonConvert.DeserializeObject<ContentResult>(content);
+            }
+
+            return apiResponse;
+        }
+    }
+
+    public class ApiResponse<T>
+    {
+        public int StatusCode { get; set; }
+        public bool IsSuccessStatusCode { get; set; }
+        public T Data { get; set; }
+        public ContentResult Error { get; set; }
+    }
+}

--- a/Models/FaqCategoryDto.cs
+++ b/Models/FaqCategoryDto.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace YourNamespace.Models
+{
+    public class FaqCategoryDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public DateTime Created { get; set; }
+        public DateTime Updated { get; set; }
+    }
+}

--- a/Tests/ApiFaqsCategoryPostPutTests.cs
+++ b/Tests/ApiFaqsCategoryPostPutTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using YourNamespace.ApiClients;
+using YourNamespace.Models;
+using FluentAssertions;
+
+namespace YourNamespace.Tests
+{
+    [TestFixture]
+    public class ApiFaqsCategoryPostPutTests
+    {
+        private FaqCategoryApiClient _apiClient;
+
+        [SetUp]
+        public void Setup()
+        {
+            var httpClient = new HttpClient();
+            _apiClient = new FaqCategoryApiClient(httpClient);
+        }
+
+        [Test]
+        public async Task AddFaqCategory_ShouldReturnAddedCategory()
+        {
+            // Arrange
+            var newCategory = new FaqCategoryDto
+            {
+                Name = "Test Category",
+                Description = "This is a test category"
+            };
+
+            // Act
+            var response = await _apiClient.AddFaqCategoryAsync(newCategory);
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+            response.IsSuccessStatusCode.Should().BeTrue();
+            response.Data.Should().NotBeNull();
+            response.Data.Id.Should().BeGreaterThan(0);
+            response.Data.Name.Should().Be(newCategory.Name);
+            response.Data.Description.Should().Be(newCategory.Description);
+            response.Data.Created.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
+            response.Data.Updated.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
+        }
+
+        [Test]
+        public async Task EditFaqCategory_ShouldReturnEditedCategory()
+        {
+            // Arrange
+            var existingCategory = new FaqCategoryDto
+            {
+                Id = 1, // Assume this category exists
+                Name = "Existing Category",
+                Description = "This is an existing category"
+            };
+
+            var updatedCategory = new FaqCategoryDto
+            {
+                Id = existingCategory.Id,
+                Name = "Updated Category Name",
+                Description = "This is an updated category description"
+            };
+
+            // Act
+            var response = await _apiClient.EditFaqCategoryAsync(updatedCategory);
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+            response.IsSuccessStatusCode.Should().BeTrue();
+            response.Data.Should().NotBeNull();
+            response.Data.Id.Should().Be(existingCategory.Id);
+            response.Data.Name.Should().Be(updatedCategory.Name);
+            response.Data.Description.Should().Be(updatedCategory.Description);
+            response.Data.Updated.Should().BeAfter(response.Data.Created);
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added `FaqCategoryDto.cs` to the `Models` directory.
- Added `FaqCategoryApiClient.cs` to the `Clients` directory.
- Added `ApiFaqsCategoryPostPutTests.cs` to the `Tests` directory.

These changes cover the requirements specified in the Swagger JSON and the test scenario for the `/api/v1/faqs/category` endpoint, allowing adding and editing FAQ categories.
