### PR TITLE
Add DTO models, API client, and NUnit tests for API-TC-001

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Text.Json;
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public QuickCommentApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={(int)category}", null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            var quickComments = JsonSerializer.Deserialize<List<QuickCommentDto>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, quickComments);
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            var errorResult = JsonSerializer.Deserialize<ContentResult>(errorContent, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, default, errorResult);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public T Data { get; }
+    public ContentResult ErrorResult { get; }
+
+    public ApiResponse(System.Net.HttpStatusCode statusCode, T data, ContentResult errorResult = null)
+    {
+        StatusCode = statusCode;
+        Data = data;
+        ErrorResult = errorResult;
+    }
+}

--- a/Models/QuickCommentCategoryDto.cs
+++ b/Models/QuickCommentCategoryDto.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceOfDonation = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Tests/ApiTc001Tests.cs
+++ b/Tests/ApiTc001Tests.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using System.Linq;
+
+[TestFixture]
+public class ApiTc001Tests
+{
+    private QuickCommentApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _client = new QuickCommentApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsQuickComments()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeAssignableTo<List<QuickCommentDto>>();
+
+        foreach (var quickComment in response.Data)
+        {
+            quickComment.Id.Should().BePositive();
+            quickComment.Comment.Should().BeOneOf(null, string.Empty).Or.BeAssignableTo<string>();
+        }
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsValidStructure()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().AllBeOfType<QuickCommentDto>();
+        response.Data.Should().OnlyContain(qc => qc.GetType().GetProperties().Select(p => p.Name).SequenceEqual(new[] { "Id", "Comment" }));
+    }
+}


### PR DESCRIPTION
This PR includes the following changes:
- Added QuickCommentCategoryDto.cs and QuickCommentDto.cs in Models/
- Added QuickCommentApiClient.cs in Clients/
- Added ApiTc001Tests.cs in Tests/

These changes cover the test case API-TC-001: Verify that the `/api/v1/QuickComments` endpoint returns a collection of QuickComments for a valid `quickCommentCategory`.
