### PR TITLE
Add C# autotests for API-QC-POST-001

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public QuickCommentApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={(int)category}", null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            var quickComments = JsonSerializer.Deserialize<List<QuickCommentDto>>(content, _jsonOptions);
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, quickComments);
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            var errorResult = JsonSerializer.Deserialize<ContentResult>(errorContent, _jsonOptions);
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, default, errorResult);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public T Data { get; }
+    public ContentResult ErrorContent { get; }
+
+    public ApiResponse(System.Net.HttpStatusCode statusCode, T data = default, ContentResult errorContent = null)
+    {
+        StatusCode = statusCode;
+        Data = data;
+        ErrorContent = errorContent;
+    }
+}

--- a/Models/QuickCommentCategory.cs
+++ b/Models/QuickCommentCategory.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceOfDonation = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Tests/ApiQcPost001Tests.cs
+++ b/Tests/ApiQcPost001Tests.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using System.Linq;
+
+[TestFixture]
+public class ApiQcPost001Tests
+{
+    private HttpClient _httpClient;
+    private QuickCommentApiClient _apiClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        _httpClient = new HttpClient();
+        _httpClient.BaseAddress = new System.Uri("https://api-base-url.com"); // Replace with actual base URL
+        _apiClient = new QuickCommentApiClient(_httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsQuickComments()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _apiClient.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeAssignableTo<List<QuickCommentDto>>();
+
+        foreach (var quickComment in response.Data)
+        {
+            quickComment.Id.Should().BePositive();
+            quickComment.Comment.Should().BeOneOf(null, string.Empty).Or.BeAssignableTo<string>();
+        }
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _httpClient.Dispose();
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:
- Added DTO models for QuickCommentCategory and QuickCommentDto
- Added QuickCommentApiClient for interacting with the /api/v1/QuickComments endpoint
- Added NUnit tests for verifying the /api/v1/QuickComments endpoint functionality

closes #API-QC-POST-001