### PR TITLE
Add DTO models, API client, and NUnit tests for API-/api/v1/QuickComments-POST-001

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public QuickCommentApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={category}", null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var comments = await response.Content.ReadFromJsonAsync<List<QuickCommentDto>>();
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, comments);
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadFromJsonAsync<ContentResult>();
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, null, errorContent);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public T Data { get; }
+    public ContentResult ErrorContent { get; }
+
+    public ApiResponse(System.Net.HttpStatusCode statusCode, T data, ContentResult errorContent = null)
+    {
+        StatusCode = statusCode;
+        Data = data;
+        ErrorContent = errorContent;
+    }
+}

--- a/Models/QuickCommentCategory.cs
+++ b/Models/QuickCommentCategory.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceComment = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Tests/ApiQuickCommentsPost001Tests.cs
+++ b/Tests/ApiQuickCommentsPost001Tests.cs
@@ -1,0 +1,65 @@
+using NUnit.Framework;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class ApiQuickCommentsPost001Tests
+{
+    private QuickCommentApiClient _client;
+    private HttpClient _httpClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        _httpClient = new HttpClient();
+        _httpClient.DefaultRequestHeaders.Add("Authorization", "Bearer {valid_token}");
+        _client = new QuickCommentApiClient(_httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeOfType<List<QuickCommentDto>>();
+        response.Data.Should().NotBeEmpty();
+
+        foreach (var comment in response.Data)
+        {
+            comment.Id.Should().BeGreaterThan(0);
+            comment.Comment.Should().NotBeNullOrEmpty();
+        }
+    }
+
+    [Test]
+    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
+    {
+        // Arrange
+        var invalidCategory = (QuickCommentCategory)999; // Invalid category
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(invalidCategory);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Data.Should().BeNull();
+        response.ErrorContent.Should().NotBeNull();
+        response.ErrorContent.StatusCode.Should().Be(400);
+        response.ErrorContent.Content.Should().NotBeNullOrEmpty();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _httpClient.Dispose();
+    }
+}


### PR DESCRIPTION
This PR includes the following changes:

- Added QuickCommentCategory enum model in Models/QuickCommentCategory.cs
- Added QuickCommentDto model in Models/QuickCommentDto.cs
- Added QuickCommentApiClient in Clients/QuickCommentApiClient.cs
- Added NUnit tests in Tests/ApiQuickCommentsPost001Tests.cs

These changes cover the test scenario for verifying that a new resource is successfully created when valid data is submitted to the /api/v1/QuickComments endpoint using the POST method.