### PR TITLE
Add DTO models, API client, and NUnit tests for API-V1-QuickComments-POST-001

### DIFF
--- a/Clients/QuickCommentsApiClient.cs
+++ b/Clients/QuickCommentsApiClient.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+public class QuickCommentsApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public QuickCommentsApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsByCategoryAsync(QuickCommentCategory category)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={category}", null);
+            
+            if (response.IsSuccessStatusCode)
+            {
+                var comments = await response.Content.ReadFromJsonAsync<List<QuickCommentDto>>();
+                return new ApiResponse<List<QuickCommentDto>>(true, comments, null);
+            }
+            else
+            {
+                var errorContent = await response.Content.ReadFromJsonAsync<ContentResult>();
+                return new ApiResponse<List<QuickCommentDto>>(false, null, errorContent);
+            }
+        }
+        catch (Exception ex)
+        {
+            return new ApiResponse<List<QuickCommentDto>>(false, null, new ContentResult { Content = ex.Message, StatusCode = 500 });
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public bool IsSuccess { get; }
+    public T Data { get; }
+    public ContentResult Error { get; }
+
+    public ApiResponse(bool isSuccess, T data, ContentResult error)
+    {
+        IsSuccess = isSuccess;
+        Data = data;
+        Error = error;
+    }
+}

--- a/Models/QuickCommentCategoryEnum.cs
+++ b/Models/QuickCommentCategoryEnum.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceOfDonation = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Tests/QuickCommentsApiTests.cs
+++ b/Tests/QuickCommentsApiTests.cs
@@ -1,0 +1,65 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using System.Collections.Generic;
+
+[TestFixture]
+public class QuickCommentsApiTests
+{
+    private QuickCommentsApiClient _client;
+    private HttpClient _httpClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        _httpClient = new HttpClient();
+        _httpClient.DefaultRequestHeaders.Add("Authorization", "Bearer valid_token_12345");
+        _client = new QuickCommentsApiClient(_httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsByCategoryAsync(category);
+
+        // Assert
+        response.IsSuccess.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeOfType<List<QuickCommentDto>>();
+        response.Error.Should().BeNull();
+
+        foreach (var comment in response.Data)
+        {
+            comment.Id.Should().BeGreaterThan(0);
+            comment.Comment.Should().NotBeNullOrEmpty();
+        }
+    }
+
+    [Test]
+    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
+    {
+        // Arrange
+        var invalidCategory = (QuickCommentCategory)999; // Invalid category
+
+        // Act
+        var response = await _client.GetQuickCommentsByCategoryAsync(invalidCategory);
+
+        // Assert
+        response.IsSuccess.Should().BeFalse();
+        response.Data.Should().BeNull();
+        response.Error.Should().NotBeNull();
+        response.Error.StatusCode.Should().Be(400);
+        response.Error.Content.Should().NotBeNullOrEmpty();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _httpClient.Dispose();
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added DTO models for QuickCommentCategory and QuickCommentDto.
- Created QuickCommentsApiClient for interacting with the /api/v1/QuickComments endpoint.
- Implemented NUnit tests in QuickCommentsApiTests.cs to verify the functionality of the endpoint.

Files added:
- Models/QuickCommentCategoryEnum.cs
- Models/QuickCommentDto.cs
- Clients/QuickCommentsApiClient.cs
- Tests/QuickCommentsApiTests.cs