### PR TITLE
Add C# autotests for API-QC-001: Verify that the /api/v1/QuickComments endpoint returns a collection of QuickComments

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public QuickCommentApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={(int)category}", null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var comments = await response.Content.ReadFromJsonAsync<List<QuickCommentDto>>();
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, comments);
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadFromJsonAsync<ContentResult>();
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, default, errorContent);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public T Data { get; }
+    public ContentResult ErrorContent { get; }
+
+    public ApiResponse(System.Net.HttpStatusCode statusCode, T data, ContentResult errorContent = null)
+    {
+        StatusCode = statusCode;
+        Data = data;
+        ErrorContent = errorContent;
+    }
+}

--- a/Models/QuickCommentCategoryEnum.cs
+++ b/Models/QuickCommentCategoryEnum.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceComment = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string? Comment { get; set; }
+}

--- a/Tests/ApiQc001Tests.cs
+++ b/Tests/ApiQc001Tests.cs
@@ -1,0 +1,71 @@
+using NUnit.Framework;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using System.Linq;
+
+[TestFixture]
+public class ApiQc001Tests
+{
+    private QuickCommentApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _client = new QuickCommentApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsQuickComments()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeAssignableTo<List<QuickCommentDto>>();
+
+        foreach (var comment in response.Data)
+        {
+            comment.Id.Should().BeGreaterThan(0);
+            comment.Comment.Should().NotBeNull();
+        }
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsCorrectContentType()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Note: We can't directly check the content type in this setup, 
+        // but we can verify that we received a valid JSON response
+        response.Data.Should().NotBeNull();
+    }
+
+    [Test]
+    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
+    {
+        // Arrange
+        var invalidCategory = (QuickCommentCategory)999; // Invalid category
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(invalidCategory);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.ErrorContent.Should().NotBeNull();
+        response.ErrorContent.StatusCode.Should().Be(400);
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added DTO model for QuickCommentCategoryEnum
- Added DTO model for QuickCommentDto
- Added API client for QuickComments endpoint
- Added NUnit tests for API-QC-001

Files:
- Models/QuickCommentCategoryEnum.cs
- Models/QuickCommentDto.cs
- Clients/QuickCommentApiClient.cs
- Tests/ApiQc001Tests.cs