### PR TITLE
Add C# autotests for API-QC-001: Verify that the /api/v1/QuickComments endpoint returns a collection of QuickComments

### DIFF
--- a/Clients/QuickCommentsApiClient.cs
+++ b/Clients/QuickCommentsApiClient.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class QuickCommentsApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public QuickCommentsApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={(int)category}", null);
+
+        var apiResponse = new ApiResponse<List<QuickCommentDto>>
+        {
+            StatusCode = (int)response.StatusCode,
+            Headers = response.Headers,
+            IsSuccessStatusCode = response.IsSuccessStatusCode
+        };
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            apiResponse.Data = JsonSerializer.Deserialize<List<QuickCommentDto>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        else
+        {
+            apiResponse.ErrorContent = await response.Content.ReadAsStringAsync();
+        }
+
+        return apiResponse;
+    }
+}
+
+public class ApiResponse<T>
+{
+    public int StatusCode { get; set; }
+    public HttpResponseHeaders Headers { get; set; }
+    public bool IsSuccessStatusCode { get; set; }
+    public T Data { get; set; }
+    public string ErrorContent { get; set; }
+}

--- a/Models/QuickCommentCategory.cs
+++ b/Models/QuickCommentCategory.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceOfDonation = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Tests/ApiQc001Tests.cs
+++ b/Tests/ApiQc001Tests.cs
@@ -1,0 +1,58 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class ApiQc001Tests
+{
+    private QuickCommentsApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _client = new QuickCommentsApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsQuickComments()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.IsSuccessStatusCode.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeAssignableTo<List<QuickCommentDto>>();
+        
+        foreach (var comment in response.Data)
+        {
+            comment.Id.Should().BeGreaterThan(0);
+            comment.Comment.Should().NotBeNull();
+        }
+
+        response.Headers.Should().ContainKey("Content-Type");
+        response.Headers.GetValues("Content-Type").Should().Contain("application/json");
+    }
+
+    [Test]
+    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
+    {
+        // Arrange
+        var invalidCategory = (QuickCommentCategory)0; // Invalid category
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(invalidCategory);
+
+        // Assert
+        response.StatusCode.Should().Be(400);
+        response.IsSuccessStatusCode.Should().BeFalse();
+        response.ErrorContent.Should().NotBeNullOrEmpty();
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added DTO model for QuickCommentDto
- Added enum for QuickCommentCategory
- Added API client for QuickCommentsApiClient
- Added NUnit tests for ApiQc001Tests

Files:
- Models/QuickCommentDto.cs
- Models/QuickCommentCategory.cs
- Clients/QuickCommentsApiClient.cs
- Tests/ApiQc001Tests.cs