### PR TITLE
Add DTO models, API client, and NUnit tests for API-QC-POST-001

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -29,7 +29,7 @@ public class QuickCommentApiClient
         {
             var errorContent = await response.Content.ReadAsStringAsync();
             var errorResult = JsonSerializer.Deserialize<ContentResult>(errorContent, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, default, errorResult);
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, null, errorResult);
         }
     }
 }
@@ -38,12 +38,12 @@ public class ApiResponse<T>
 {
     public System.Net.HttpStatusCode StatusCode { get; }
     public T Data { get; }
-    public ContentResult ErrorContent { get; }
+    public ContentResult ErrorResult { get; }
 
-    public ApiResponse(System.Net.HttpStatusCode statusCode, T data, ContentResult errorContent = null)
+    public ApiResponse(System.Net.HttpStatusCode statusCode, T data, ContentResult errorResult = null)
     {
         StatusCode = statusCode;
         Data = data;
-        ErrorContent = errorContent;
+        ErrorResult = errorResult;
     }
 }

--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public QuickCommentApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={(int)category}", null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            var quickComments = JsonSerializer.Deserialize<List<QuickCommentDto>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, quickComments);
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            var errorResult = JsonSerializer.Deserialize<ContentResult>(errorContent, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, default, errorResult);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public T Data { get; }
+    public ContentResult ErrorContent { get; }
+
+    public ApiResponse(System.Net.HttpStatusCode statusCode, T data, ContentResult errorContent = null)
+    {
+        StatusCode = statusCode;
+        Data = data;
+        ErrorContent = errorContent;
+    }
+}

--- a/Models/QuickCommentCategory.cs
+++ b/Models/QuickCommentCategory.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceComment = 2,
+    Other = 3
+}

--- a/Models/QuickCommentCategoryEnum.cs
+++ b/Models/QuickCommentCategoryEnum.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceComment = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Tests/ApiQcPost001Tests.cs
+++ b/Tests/ApiQcPost001Tests.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using System.Linq;
+
+[TestFixture]
+public class ApiQcPost001Tests
+{
+    private QuickCommentApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _client = new QuickCommentApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsQuickComments()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeAssignableTo<List<QuickCommentDto>>();
+
+        foreach (var quickComment in response.Data)
+        {
+            quickComment.Id.Should().BeGreaterThan(0);
+            quickComment.Comment.Should().NotBeNull();
+        }
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsCorrectStructure()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeAssignableTo<List<QuickCommentDto>>();
+
+        response.Data.Should().AllSatisfy(quickComment =>
+        {
+            quickComment.Should().NotBeNull();
+            quickComment.Id.Should().BeGreaterThan(0);
+            quickComment.Comment.Should().BeOfType<string>().Or.BeNull();
+        });
+    }
+}


### PR DESCRIPTION
This PR includes the following changes:

- Added QuickCommentCategoryEnum.cs and QuickCommentDto.cs to Models directory.
- Added QuickCommentApiClient.cs to Clients directory.
- Added ApiQcPost001Tests.cs to Tests directory.

These changes cover the test scenario for verifying that the `/api/v1/QuickComments` endpoint returns a collection of QuickComments for a valid `quickCommentCategory`.

closes #API-QC-POST-001