### PR TITLE
Add tests for TC_API_QuickComments_001

### DIFF
--- a/Clients/QuickCommentsApiClient.cs
+++ b/Clients/QuickCommentsApiClient.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Text.Json;
+
+public class QuickCommentsApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public QuickCommentsApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={(int)category}", null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            var quickComments = JsonSerializer.Deserialize<List<QuickCommentDto>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, quickComments);
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            var errorResult = JsonSerializer.Deserialize<ContentResult>(errorContent, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, null, errorResult);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public T Data { get; }
+    public ContentResult ErrorResult { get; }
+
+    public ApiResponse(System.Net.HttpStatusCode statusCode, T data, ContentResult errorResult = null)
+    {
+        StatusCode = statusCode;
+        Data = data;
+        ErrorResult = errorResult;
+    }
+}

--- a/Models/QuickCommentCategory.cs
+++ b/Models/QuickCommentCategory.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceOfDonation = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Tests/TC_API_QuickComments_001Tests.cs
+++ b/Tests/TC_API_QuickComments_001Tests.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using FluentAssertions;
+
+[TestFixture]
+public class TC_API_QuickComments_001Tests
+{
+    private QuickCommentsApiClient _apiClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _apiClient = new QuickCommentsApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsQuickComments()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _apiClient.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeAssignableTo<List<QuickCommentDto>>();
+
+        foreach (var quickComment in response.Data)
+        {
+            quickComment.Id.Should().BeGreaterThan(0);
+            quickComment.Comment.Should().NotBeNull();
+        }
+    }
+
+    [Test]
+    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
+    {
+        // Arrange
+        var invalidCategory = (QuickCommentCategory)999; // Invalid category
+
+        // Act
+        var response = await _apiClient.GetQuickCommentsAsync(invalidCategory);
+
+        // Assert
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        response.Data.Should().BeNull();
+        response.ErrorResult.Should().NotBeNull();
+        response.ErrorResult.StatusCode.Should().Be(400);
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:
- Added QuickCommentDto model in Models/QuickCommentDto.cs
- Added QuickCommentCategory model in Models/QuickCommentCategory.cs
- Added QuickCommentsApiClient in Clients/QuickCommentsApiClient.cs
- Added NUnit tests in Tests/TC_API_QuickComments_001Tests.cs

These changes cover the test case TC_API_QuickComments_001: Verify that the `/api/v1/QuickComments` endpoint returns a collection of QuickComments for a valid category.