### PR TITLE
Add DTO models, API client, and NUnit tests for API-QC-POST-001

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public QuickCommentApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsByCategoryAsync(QuickCommentCategory category)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={category}", null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            var quickComments = JsonSerializer.Deserialize<List<QuickCommentDto>>(content, _jsonOptions);
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, quickComments);
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            var errorResult = JsonSerializer.Deserialize<ContentResult>(errorContent, _jsonOptions);
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, errorResult);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public T Data { get; }
+    public ContentResult ErrorResult { get; }
+
+    public ApiResponse(System.Net.HttpStatusCode statusCode, T data)
+    {
+        StatusCode = statusCode;
+        Data = data;
+    }
+
+    public ApiResponse(System.Net.HttpStatusCode statusCode, ContentResult errorResult)
+    {
+        StatusCode = statusCode;
+        ErrorResult = errorResult;
+    }
+}

--- a/Models/QuickCommentCategory.cs
+++ b/Models/QuickCommentCategory.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceComment = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Tests/ApiQcPost001Tests.cs
+++ b/Tests/ApiQcPost001Tests.cs
@@ -1,0 +1,52 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using System.Net;
+using System.Collections.Generic;
+
+[TestFixture]
+public class ApiQcPost001Tests
+{
+    private HttpClient _httpClient;
+    private QuickCommentApiClient _apiClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        _httpClient = new HttpClient();
+        _httpClient.BaseAddress = new System.Uri("https://api-base-url.com"); // Replace with actual base URL
+        _apiClient = new QuickCommentApiClient(_httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_WithValidCategory_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _apiClient.GetQuickCommentsByCategoryAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Data.Should().NotBeNull().And.BeOfType<List<QuickCommentDto>>();
+        response.Data.Should().NotBeEmpty();
+
+        foreach (var quickComment in response.Data)
+        {
+            quickComment.Id.Should().BeGreaterThan(0);
+            quickComment.Comment.Should().NotBeNull();
+        }
+
+        // Verify content type (this would typically be done at the HttpClient level, 
+        // but we're assuming it here based on the API client implementation)
+        _httpClient.DefaultRequestHeaders.Accept.Should().Contain(header => header.MediaType == "application/json");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _httpClient.Dispose();
+    }
+}


### PR DESCRIPTION
Implemented the following:
- QuickCommentCategory.cs: Enum representing quick comment categories.
- QuickCommentDto.cs: DTO model for quick comments.
- QuickCommentApiClient.cs: API client for interacting with the /api/v1/QuickComments endpoint.
- ApiQcPost001Tests.cs: NUnit tests for verifying the successful retrieval of quick comments by category.

closes #58