### PR TITLE
Add API client, DTO model, and NUnit tests for API-PUSH-NOTIFICATION-POST-001

### DIFF
--- a/Clients/PushNotificationApiClient.cs
+++ b/Clients/PushNotificationApiClient.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class PushNotificationApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public PushNotificationApiClient(string baseUrl)
+    {
+        _baseUrl = baseUrl;
+        _httpClient = new HttpClient();
+    }
+
+    public async Task<ApiResponse<ContentResult>> CreatePushNotificationAsync(PushNotificationDto pushNotification)
+    {
+        var url = $"{_baseUrl}/api/v1/PushNotification";
+        var json = JsonConvert.SerializeObject(pushNotification);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PostAsync(url, content);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return new ApiResponse<ContentResult>
+        {
+            StatusCode = (int)response.StatusCode,
+            Data = JsonConvert.DeserializeObject<ContentResult>(responseContent)
+        };
+    }
+}
+
+public class ApiResponse<T>
+{
+    public int StatusCode { get; set; }
+    public T Data { get; set; }
+}

--- a/Models/PushNotificationDto.cs
+++ b/Models/PushNotificationDto.cs
@@ -1,0 +1,17 @@
+using System;
+
+public class PushNotificationDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public int CategoryId { get; set; }
+    public int? TriggerId { get; set; }
+    public string ShortDescription { get; set; }
+    public string LongDescription { get; set; }
+    public DateTime NotificationDistribution { get; set; }
+    public string CreatedById { get; set; }
+    public string LastUpdatedById { get; set; }
+    public DateTime Created { get; set; }
+    public DateTime Updated { get; set; }
+    public bool IsDisabled { get; set; }
+}

--- a/Tests/ApiPushNotificationPost001Tests.cs
+++ b/Tests/ApiPushNotificationPost001Tests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class ApiPushNotificationPost001Tests
+{
+    private PushNotificationApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        _client = new PushNotificationApiClient("https://api.example.com"); // Replace with actual base URL
+    }
+
+    [Test]
+    public async Task CreatePushNotification_ValidPayload_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+        var pushNotification = new PushNotificationDto
+        {
+            Name = "Test Notification",
+            CategoryId = 1,
+            ShortDescription = "Short description",
+            LongDescription = "Long description",
+            NotificationDistribution = DateTime.UtcNow.AddDays(1),
+            CreatedById = "user1",
+            LastUpdatedById = "user1",
+            Created = DateTime.UtcNow,
+            Updated = DateTime.UtcNow,
+            IsDisabled = false
+        };
+
+        // Act
+        var response = await _client.CreatePushNotificationAsync(pushNotification);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.StatusCode.Should().Be(200);
+        response.Data.Content.Should().NotBeNullOrEmpty();
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added `PushNotificationDto.cs` to the `Models` directory.
- Added `PushNotificationApiClient.cs` to the `Clients` directory.
- Added `ApiPushNotificationPost001Tests.cs` to the `Tests` directory.

These changes cover the test scenario for verifying that the `/api/v1/PushNotification` endpoint creates a new push notification.

closes #API-PUSH-NOTIFICATION-POST-001