### PR TITLE
Add C# autotests for API-GET-REGIONS-001

### DIFF
--- a/ApiClients/LocationApiClient.cs
+++ b/ApiClients/LocationApiClient.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using YourNamespace.Models;
+
+namespace YourNamespace.ApiClients
+{
+    public class LocationApiClient
+    {
+        private readonly HttpClient _httpClient;
+
+        public LocationApiClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        }
+
+        public async Task<ApiResponse<List<RegionDto>>> GetRegionsAsync()
+        {
+            var response = await _httpClient.GetAsync("/api/v1/regions");
+            
+            if (response.IsSuccessStatusCode)
+            {
+                var regions = await response.Content.ReadFromJsonAsync<List<RegionDto>>();
+                return new ApiResponse<List<RegionDto>>(response.StatusCode, regions);
+            }
+            else if (response.StatusCode == System.Net.HttpStatusCode.InternalServerError)
+            {
+                var errorContent = await response.Content.ReadFromJsonAsync<ContentResult>();
+                return new ApiResponse<List<RegionDto>>(response.StatusCode, default, errorContent);
+            }
+            else
+            {
+                return new ApiResponse<List<RegionDto>>(response.StatusCode);
+            }
+        }
+    }
+
+    public class ApiResponse<T>
+    {
+        public System.Net.HttpStatusCode StatusCode { get; }
+        public T Data { get; }
+        public ContentResult ErrorContent { get; }
+
+        public ApiResponse(System.Net.HttpStatusCode statusCode, T data = default, ContentResult errorContent = null)
+        {
+            StatusCode = statusCode;
+            Data = data;
+            ErrorContent = errorContent;
+        }
+    }
+}

--- a/Models/RegionDto.cs
+++ b/Models/RegionDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace YourNamespace.Models
+{
+    public class RegionDto
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+    }
+}

--- a/Tests/ApiGetRegions001Tests.cs
+++ b/Tests/ApiGetRegions001Tests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using FluentAssertions;
+using YourNamespace.ApiClients;
+using YourNamespace.Models;
+
+namespace YourNamespace.Tests
+{
+    [TestFixture]
+    public class ApiGetRegions001Tests
+    {
+        private HttpClient _httpClient;
+        private LocationApiClient _locationApiClient;
+
+        [SetUp]
+        public void Setup()
+        {
+            _httpClient = new HttpClient
+            {
+                BaseAddress = new Uri("https://your-api-base-url.com")
+            };
+            _locationApiClient = new LocationApiClient(_httpClient);
+        }
+
+        [Test]
+        public async Task GetRegions_ReturnsSuccessfulResponse()
+        {
+            // Arrange
+            // No additional arrangement needed as we're testing a GET request without parameters
+
+            // Act
+            var response = await _locationApiClient.GetRegionsAsync();
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Data.Should().NotBeNull();
+            response.Data.Should().BeAssignableTo<List<RegionDto>>();
+
+            foreach (var region in response.Data)
+            {
+                region.Id.Should().BeGreaterThan(0);
+                region.Name.Should().BeOfType<string>().Or.BeNull();
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _httpClient.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Implemented the following files to cover the test scenario for the `/api/v1/regions` endpoint:

- **Models/RegionDto.cs**: Defines the RegionDto model.
- **ApiClients/LocationApiClient.cs**: Contains the API client for the Location API.
- **Tests/ApiGetRegions001Tests.cs**: Implements the NUnit tests for the API-GET-REGIONS-001 scenario.

This PR ensures that the `/api/v1/regions` endpoint successfully retrieves all regions with a 200 status code and validates the response structure.

closes #API-GET-REGIONS-001