### PR TITLE
Add C# autotests for API-USER-PASSWORD-PUT: Verify that the /api/v1/user/password endpoint updates the user password

### DIFF
--- a/Clients/UserApiClient.cs
+++ b/Clients/UserApiClient.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class UserApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public UserApiClient(string baseUrl)
+    {
+        _baseUrl = baseUrl;
+        _httpClient = new HttpClient();
+    }
+
+    public async Task<ApiResponse<ContentResult>> ChangePasswordAsync(UserChangePasswordModel model)
+    {
+        var json = JsonConvert.SerializeObject(model);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PutAsync($"{_baseUrl}/api/v1/user/password", content);
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var contentResult = JsonConvert.DeserializeObject<ContentResult>(responseContent);
+
+        return new ApiResponse<ContentResult>
+        {
+            StatusCode = (int)response.StatusCode,
+            Data = contentResult
+        };
+    }
+}
+
+public class ApiResponse<T>
+{
+    public int StatusCode { get; set; }
+    public T Data { get; set; }
+}

--- a/Models/ContentResult.cs
+++ b/Models/ContentResult.cs
@@ -1,5 +1,6 @@
 public class ContentResult
 {
     public string Content { get; set; }
-    public int StatusCode { get; set; }
+    public string ContentType { get; set; }
+    public int? StatusCode { get; set; }
 }

--- a/Models/UserChangePasswordModel.cs
+++ b/Models/UserChangePasswordModel.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+public class UserChangePasswordModel
+{
+    [Required]
+    [Phone]
+    public string PhoneNumber { get; set; }
+
+    [Required]
+    public string OldPassword { get; set; }
+
+    [Required]
+    public string Password { get; set; }
+}

--- a/Tests/UserChangePasswordTests.cs
+++ b/Tests/UserChangePasswordTests.cs
@@ -1,0 +1,95 @@
+using NUnit.Framework;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class UserChangePasswordTests
+{
+    private UserApiClient _apiClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        _apiClient = new UserApiClient("https://api.example.com"); // Replace with actual base URL
+    }
+
+    [Test]
+    public async Task ChangePassword_ValidData_ShouldSucceed()
+    {
+        // Arrange
+        var model = new UserChangePasswordModel
+        {
+            PhoneNumber = "+1234567890",
+            OldPassword = "oldPassword123",
+            Password = "newPassword456"
+        };
+
+        // Act
+        var response = await _apiClient.ChangePasswordAsync(model);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Content.Should().Be("Password was successfully updated");
+    }
+
+    [Test]
+    public async Task ChangePassword_InvalidOldPassword_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var model = new UserChangePasswordModel
+        {
+            PhoneNumber = "+1234567890",
+            OldPassword = "wrongOldPassword",
+            Password = "newPassword456"
+        };
+
+        // Act
+        var response = await _apiClient.ChangePasswordAsync(model);
+
+        // Assert
+        response.StatusCode.Should().Be(400);
+        response.Data.Should().NotBeNull();
+        response.Data.Content.Should().Contain("Invalid old password");
+    }
+
+    [Test]
+    public async Task ChangePassword_InvalidPhoneNumber_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var model = new UserChangePasswordModel
+        {
+            PhoneNumber = "invalidPhoneNumber",
+            OldPassword = "oldPassword123",
+            Password = "newPassword456"
+        };
+
+        // Act
+        var response = await _apiClient.ChangePasswordAsync(model);
+
+        // Assert
+        response.StatusCode.Should().Be(400);
+        response.Data.Should().NotBeNull();
+        response.Data.Content.Should().Contain("Invalid phone number format");
+    }
+
+    [Test]
+    public async Task ChangePassword_WeakNewPassword_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var model = new UserChangePasswordModel
+        {
+            PhoneNumber = "+1234567890",
+            OldPassword = "oldPassword123",
+            Password = "weak"
+        };
+
+        // Act
+        var response = await _apiClient.ChangePasswordAsync(model);
+
+        // Assert
+        response.StatusCode.Should().Be(400);
+        response.Data.Should().NotBeNull();
+        response.Data.Content.Should().Contain("Password does not meet complexity requirements");
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added DTO model `UserChangePasswordModel` in `Models/UserChangePasswordModel.cs`
- Updated DTO model `ContentResult` in `Models/ContentResult.cs`
- Added API client `UserApiClient` in `Clients/UserApiClient.cs`
- Added NUnit tests in `Tests/UserChangePasswordTests.cs`

These changes cover the functionality for changing the user password using the `/api/v1/user/password` endpoint as described in the Swagger JSON fragment.