### PR TITLE
Add DTO models, API client, and NUnit tests for API-TC-001: Verify successful retrieval of QuickComments by category

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public QuickCommentApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsByCategoryAsync(QuickCommentCategory category)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={category}", null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            var quickComments = JsonSerializer.Deserialize<List<QuickCommentDto>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, quickComments);
+        }
+
+        return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, null, await response.Content.ReadAsStringAsync());
+    }
+}
+
+public class ApiResponse<T>
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public T Data { get; }
+    public string ErrorMessage { get; }
+
+    public ApiResponse(System.Net.HttpStatusCode statusCode, T data, string errorMessage = null)
+    {
+        StatusCode = statusCode;
+        Data = data;
+        ErrorMessage = errorMessage;
+    }
+}

--- a/Models/QuickCommentCategoryEnum.cs
+++ b/Models/QuickCommentCategoryEnum.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceOfDonation = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Tests/ApiTc001Tests.cs
+++ b/Tests/ApiTc001Tests.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using System.Linq;
+
+[TestFixture]
+public class ApiTc001Tests
+{
+    private QuickCommentApiClient _apiClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _apiClient = new QuickCommentApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_SuccessfulRetrieval()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _apiClient.GetQuickCommentsByCategoryAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeAssignableTo<List<QuickCommentDto>>();
+
+        foreach (var quickComment in response.Data)
+        {
+            quickComment.Id.Should().BeGreaterThan(0);
+            quickComment.Comment.Should().BeOfType<string>().Or.BeNull();
+        }
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidateResponseStructure()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _apiClient.GetQuickCommentsByCategoryAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeAssignableTo<List<QuickCommentDto>>();
+
+        response.Data.Should().AllSatisfy(quickComment =>
+        {
+            quickComment.Should().NotBeNull();
+            quickComment.Id.Should().BeGreaterThan(0);
+            quickComment.Comment.Should().BeOfType<string>().Or.BeNull();
+        });
+    }
+}


### PR DESCRIPTION
Files added:
- Models/QuickCommentCategoryEnum.cs
- Models/QuickCommentDto.cs
- Clients/QuickCommentApiClient.cs
- Tests/ApiTc001Tests.cs

This PR includes the implementation of the test scenario for verifying the successful retrieval of QuickComments by category.