### PR TITLE
Add tests for API-USER-PUT-001

### DIFF
--- a/Clients/UserApiClient.cs
+++ b/Clients/UserApiClient.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class UserApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public UserApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<ContentResult>> ChangePasswordAsync(UserChangePasswordModel model)
+    {
+        var json = JsonConvert.SerializeObject(model);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PutAsync("/api/v1/user/password", content);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return new ApiResponse<ContentResult>
+        {
+            StatusCode = (int)response.StatusCode,
+            Data = JsonConvert.DeserializeObject<ContentResult>(responseContent)
+        };
+    }
+
+    public async Task<ApiResponse<ContentResult>> CreatePasswordAsync(CreatePasswordViewModel model)
+    {
+        var json = JsonConvert.SerializeObject(model);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PostAsync("/api/v1/user/password", content);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return new ApiResponse<ContentResult>
+        {
+            StatusCode = (int)response.StatusCode,
+            Data = JsonConvert.DeserializeObject<ContentResult>(responseContent)
+        };
+    }
+}
+
+public class ApiResponse<T>
+{
+    public int StatusCode { get; set; }
+    public T Data { get; set; }
+}

--- a/Models/CreatePasswordViewModel.cs
+++ b/Models/CreatePasswordViewModel.cs
@@ -1,0 +1,5 @@
+public class CreatePasswordViewModel
+{
+    public string Password { get; set; }
+    public string Email { get; set; }
+}

--- a/Models/UserChangePasswordModel.cs
+++ b/Models/UserChangePasswordModel.cs
@@ -1,0 +1,6 @@
+public class UserChangePasswordModel
+{
+    public string OldPassword { get; set; }
+    public string Password { get; set; }
+    public string PhoneNumber { get; set; }
+}

--- a/Tests/ApiUserPut001Tests.cs
+++ b/Tests/ApiUserPut001Tests.cs
@@ -1,0 +1,59 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class ApiUserPut001Tests
+{
+    private UserApiClient _userApiClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _userApiClient = new UserApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task ChangePassword_WithValidModel_ShouldReturnSuccessResponse()
+    {
+        // Arrange
+        var changePasswordModel = new UserChangePasswordModel
+        {
+            OldPassword = "oldPassword123",
+            Password = "newPassword456",
+            PhoneNumber = "+1234567890"
+        };
+
+        // Act
+        var response = await _userApiClient.ChangePasswordAsync(changePasswordModel);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.StatusCode.Should().Be(200);
+        response.Data.Content.Should().NotBeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task ChangePassword_WithInvalidModel_ShouldReturnBadRequestResponse()
+    {
+        // Arrange
+        var changePasswordModel = new UserChangePasswordModel
+        {
+            OldPassword = "",
+            Password = "",
+            PhoneNumber = ""
+        };
+
+        // Act
+        var response = await _userApiClient.ChangePasswordAsync(changePasswordModel);
+
+        // Assert
+        response.StatusCode.Should().Be(400);
+        response.Data.Should().NotBeNull();
+        response.Data.StatusCode.Should().Be(400);
+        response.Data.Content.Should().NotBeNullOrEmpty();
+    }
+}


### PR DESCRIPTION
This PR includes the following changes:
- Added DTO models for UserChangePasswordModel and CreatePasswordViewModel.
- Added UserApiClient for handling API requests.
- Added NUnit tests for verifying the /api/v1/user/password endpoint.

Files added:
- Models/UserChangePasswordModel.cs
- Models/CreatePasswordViewModel.cs
- Clients/UserApiClient.cs
- Tests/ApiUserPut001Tests.cs