### PR TITLE
Add tests for API-TC-001: Verify Successful Response for Valid Input

### DIFF
--- a/Clients/UserApiClient.cs
+++ b/Clients/UserApiClient.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class UserApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public UserApiClient(string baseUrl)
+    {
+        _baseUrl = baseUrl;
+        _httpClient = new HttpClient();
+    }
+
+    public async Task<ApiResponse<ContentResult>> ChangePasswordAsync(UserChangePasswordModel model)
+    {
+        var json = JsonConvert.SerializeObject(model);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PutAsync($"{_baseUrl}/api/v1/user/password", content);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return new ApiResponse<ContentResult>
+        {
+            StatusCode = (int)response.StatusCode,
+            Data = JsonConvert.DeserializeObject<ContentResult>(responseContent)
+        };
+    }
+
+    public async Task<ApiResponse<ContentResult>> CreatePasswordAsync(CreatePasswordViewModel model)
+    {
+        var json = JsonConvert.SerializeObject(model);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PostAsync($"{_baseUrl}/api/v1/user/password", content);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return new ApiResponse<ContentResult>
+        {
+            StatusCode = (int)response.StatusCode,
+            Data = JsonConvert.DeserializeObject<ContentResult>(responseContent)
+        };
+    }
+}
+
+public class ApiResponse<T>
+{
+    public int StatusCode { get; set; }
+    public T Data { get; set; }
+}

--- a/Models/CreatePasswordViewModel.cs
+++ b/Models/CreatePasswordViewModel.cs
@@ -1,0 +1,5 @@
+public class CreatePasswordViewModel
+{
+    public string Password { get; set; }
+    public string Email { get; set; }
+}

--- a/Models/UserChangePasswordModel.cs
+++ b/Models/UserChangePasswordModel.cs
@@ -1,0 +1,6 @@
+public class UserChangePasswordModel
+{
+    public string OldPassword { get; set; }
+    public string Password { get; set; }
+    public string PhoneNumber { get; set; }
+}

--- a/Tests/ApiTc001Tests.cs
+++ b/Tests/ApiTc001Tests.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class ApiTc001Tests
+{
+    private UserApiClient _client;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    [SetUp]
+    public void Setup()
+    {
+        _client = new UserApiClient(BaseUrl);
+    }
+
+    [Test]
+    public async Task ChangePassword_ValidInput_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+        var model = new UserChangePasswordModel
+        {
+            OldPassword = "oldPassword123",
+            Password = "newPassword456",
+            PhoneNumber = "+1234567890"
+        };
+
+        // Act
+        var response = await _client.ChangePasswordAsync(model);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Content.Should().NotBeNullOrEmpty();
+        response.Data.StatusCode.Should().Be(200);
+    }
+
+    [Test]
+    public async Task CreatePassword_ValidInput_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+        var model = new CreatePasswordViewModel
+        {
+            Password = "newPassword789",
+            Email = "user@example.com"
+        };
+
+        // Act
+        var response = await _client.CreatePasswordAsync(model);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Content.Should().NotBeNullOrEmpty();
+        response.Data.StatusCode.Should().Be(200);
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added DTO models for UserChangePasswordModel and CreatePasswordViewModel.
- Added UserApiClient for handling API requests to /api/v1/user/password endpoint.
- Added NUnit tests for verifying successful responses for valid input.

Files added:
- Models/UserChangePasswordModel.cs
- Models/CreatePasswordViewModel.cs
- Clients/UserApiClient.cs
- Tests/ApiTc001Tests.cs