### PR TITLE
Add C# autotests for API-TC-001: Verify successful response for creating a new user

### DIFF
--- a/Clients/UserApiClient.cs
+++ b/Clients/UserApiClient.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class UserApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public UserApiClient(string baseUrl)
+    {
+        _baseUrl = baseUrl;
+        _httpClient = new HttpClient();
+    }
+
+    public async Task<ApiResponse<ContentResult>> ChangePasswordAsync(UserChangePasswordModel model)
+    {
+        var response = await SendRequestAsync<ContentResult>(HttpMethod.Put, "/api/v1/user/password", model);
+        return response;
+    }
+
+    public async Task<ApiResponse<ContentResult>> CreatePasswordAsync(CreatePasswordViewModel model)
+    {
+        var response = await SendRequestAsync<ContentResult>(HttpMethod.Post, "/api/v1/user/password", model);
+        return response;
+    }
+
+    private async Task<ApiResponse<T>> SendRequestAsync<T>(HttpMethod method, string endpoint, object data = null)
+    {
+        var request = new HttpRequestMessage(method, `${_baseUrl}${endpoint}`);
+
+        if (data != null)
+        {
+            var json = JsonConvert.SerializeObject(data);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        var response = await _httpClient.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        return new ApiResponse<T>
+        {
+            StatusCode = (int)response.StatusCode,
+            Content = JsonConvert.DeserializeObject<T>(content)
+        };
+    }
+}
+
+public class ApiResponse<T>
+{
+    public int StatusCode { get; set; }
+    public T Content { get; set; }
+}

--- a/Models/CreatePasswordViewModel.cs
+++ b/Models/CreatePasswordViewModel.cs
@@ -1,0 +1,5 @@
+public class CreatePasswordViewModel
+{
+    public string Password { get; set; }
+    public string Email { get; set; }
+}

--- a/Models/UserChangePasswordModel.cs
+++ b/Models/UserChangePasswordModel.cs
@@ -1,0 +1,6 @@
+public class UserChangePasswordModel
+{
+    public string OldPassword { get; set; }
+    public string Password { get; set; }
+    public string PhoneNumber { get; set; }
+}

--- a/Tests/ApiTc001Tests.cs
+++ b/Tests/ApiTc001Tests.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class ApiTc001Tests
+{
+    private UserApiClient _client;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    [SetUp]
+    public void Setup()
+    {
+        _client = new UserApiClient(BaseUrl);
+    }
+
+    [Test]
+    public async Task CreateUser_ValidData_ReturnsCreatedStatus()
+    {
+        // Arrange
+        var createUserModel = new CreateUserModel
+        {
+            Name = "John Doe",
+            Email = "johndoe@example.com",
+            Password = "SecurePassword123"
+        };
+
+        // Act
+        var response = await _client.CreateUserAsync(createUserModel);
+
+        // Assert
+        response.StatusCode.Should().Be(201);
+        response.Content.Should().NotBeNull();
+        response.Content.Name.Should().Be("John Doe");
+        response.Content.Email.Should().Be("johndoe@example.com");
+        response.Content.Id.Should().NotBeNullOrEmpty();
+    }
+}
+
+// Note: This test case assumes the existence of a CreateUserModel and a CreateUserAsync method,
+// which are not present in the provided Swagger fragment. You may need to adjust the test
+// based on the actual API structure for creating users.


### PR DESCRIPTION
This pull request includes the following changes:

- Added DTO models for UserChangePasswordModel and CreatePasswordViewModel.
- Added API client for handling user password changes and creation.
- Added NUnit tests for verifying the creation of a new user.

Files added:
- Models/UserChangePasswordModel.cs
- Models/CreatePasswordViewModel.cs
- Clients/UserApiClient.cs
- Tests/ApiTc001Tests.cs