### PR TITLE
Add DTO model, API client, and NUnit tests for API-TC-001: Validate successful editing of a donation type using the PUT `/api/v1/donation/types` endpoint

### DIFF
--- a/Clients/DonationTypeApiClient.cs
+++ b/Clients/DonationTypeApiClient.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class DonationTypeApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public DonationTypeApiClient(string baseUrl, string token)
+    {
+        _baseUrl = baseUrl;
+        _httpClient = new HttpClient();
+        _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+    }
+
+    public async Task<ApiResponse<ContentResult>> UpdateDonationTypeAsync(DonationTypeDto donationTypeDto)
+    {
+        var json = JsonConvert.SerializeObject(donationTypeDto);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PutAsync($"{_baseUrl}/api/v1/donation/types", content);
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var contentResult = JsonConvert.DeserializeObject<ContentResult>(responseContent);
+
+        return new ApiResponse<ContentResult>
+        {
+            StatusCode = (int)response.StatusCode,
+            Data = contentResult
+        };
+    }
+}
+
+public class ApiResponse<T>
+{
+    public int StatusCode { get; set; }
+    public T Data { get; set; }
+}

--- a/Models/DonationTypeDto.cs
+++ b/Models/DonationTypeDto.cs
@@ -1,0 +1,15 @@
+using System;
+
+public class DonationTypeDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string ShortDescription { get; set; }
+    public string LongDescription { get; set; }
+    public string IconData { get; set; }
+    public DateTime CreateDate { get; set; }
+    public string CreatedBy { get; set; }
+    public DateTime UpdateDate { get; set; }
+    public string LastUpdatedBy { get; set; }
+    public string HeaderColor { get; set; }
+}

--- a/Tests/ApiTc001Tests.cs
+++ b/Tests/ApiTc001Tests.cs
@@ -1,0 +1,47 @@
+using System;
+using NUnit.Framework;
+using FluentAssertions;
+using System.Threading.Tasks;
+
+[TestFixture]
+public class ApiTc001Tests
+{
+    private DonationTypeApiClient _apiClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        string baseUrl = "https://api.example.com"; // Replace with actual base URL
+        string token = "valid_token"; // Replace with actual token
+        _apiClient = new DonationTypeApiClient(baseUrl, token);
+    }
+
+    [Test]
+    public async Task UpdateDonationType_ValidPayload_ReturnsSuccessResponse()
+    {
+        // Arrange
+        var donationTypeDto = new DonationTypeDto
+        {
+            Id = 1,
+            Name = "Updated Donation Type",
+            ShortDescription = "Updated short description",
+            LongDescription = "Updated long description",
+            IconData = "base64encodedstring",
+            CreateDate = DateTime.Parse("2023-01-01T12:00:00Z"),
+            CreatedBy = "admin",
+            UpdateDate = DateTime.Parse("2023-10-01T12:00:00Z"),
+            LastUpdatedBy = "editor",
+            HeaderColor = "#FFFFFF"
+        };
+
+        // Act
+        var response = await _apiClient.UpdateDonationTypeAsync(donationTypeDto);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Content.Should().Be("Donation type successfully updated.");
+        response.Data.ContentType.Should().Be("application/json");
+        response.Data.StatusCode.Should().Be(200);
+    }
+}


### PR DESCRIPTION
Files added:
- Models/DonationTypeDto.cs
- Clients/DonationTypeApiClient.cs
- Tests/ApiTc001Tests.cs