### PR TITLE
Add C# autotests for API-TC-001: Validate successful retrieval of all donation types using GET /api/v1/donation/types

### DIFF
--- a/Clients/DonationTypesApiClient.cs
+++ b/Clients/DonationTypesApiClient.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using DonorApp.Services.DTO;
+
+namespace DonorApp.ApiClient
+{
+    public class DonationTypesApiClient
+    {
+        private readonly HttpClient _httpClient;
+        private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+        public DonationTypesApiClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+            _httpClient.BaseAddress = new Uri(BaseUrl);
+        }
+
+        public async Task<List<DonationTypeDto>> GetDonationTypesAsync()
+        {
+            var response = await _httpClient.GetAsync("/api/v1/donation/types");
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<List<DonationTypeDto>>();
+        }
+
+        public async Task<HttpResponseMessage> AddDonationTypeAsync(DonationTypeDto donationType)
+        {
+            return await _httpClient.PostAsJsonAsync("/api/v1/donation/types", donationType);
+        }
+
+        public async Task<HttpResponseMessage> EditDonationTypeAsync(DonationTypeDto donationType)
+        {
+            return await _httpClient.PutAsJsonAsync("/api/v1/donation/types", donationType);
+        }
+    }
+}

--- a/Models/DonationTypeDto.cs
+++ b/Models/DonationTypeDto.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace DonorApp.Services.DTO
+{
+    public class DonationTypeDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/Tests/ApiTc001Tests.cs
+++ b/Tests/ApiTc001Tests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using DonorApp.ApiClient;
+using DonorApp.Services.DTO;
+using NUnit.Framework;
+using FluentAssertions;
+
+namespace DonorApp.Tests
+{
+    [TestFixture]
+    public class ApiTc001Tests
+    {
+        private DonationTypesApiClient _client;
+
+        [SetUp]
+        public void Setup()
+        {
+            var httpClient = new HttpClient();
+            // Add any necessary headers, like authentication token
+            httpClient.DefaultRequestHeaders.Add("Authorization", "Bearer <valid_token>");
+            _client = new DonationTypesApiClient(httpClient);
+        }
+
+        [Test]
+        public async Task GetDonationTypes_ReturnsSuccessfulResponse()
+        {
+            // Arrange
+            // No additional arrangement needed as the client is set up in the Setup method
+
+            // Act
+            var result = await _client.GetDonationTypesAsync();
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<List<DonationTypeDto>>();
+            result.Should().NotBeEmpty();
+
+            foreach (var donationType in result)
+            {
+                donationType.Id.Should().BeGreaterThan(0);
+                donationType.Name.Should().NotBeNullOrEmpty();
+                donationType.Description.Should().NotBeNullOrEmpty();
+            }
+
+            // Example assertion for a specific donation type (adjust as needed)
+            result.Should().Contain(dt => 
+                dt.Id == 1 && 
+                dt.Name == "Blood Donation" && 
+                dt.Description == "Donation of blood or blood components");
+        }
+    }
+}


### PR DESCRIPTION
Files added:
- Models/DonationTypeDto.cs
- Clients/DonationTypesApiClient.cs
- Tests/ApiTc001Tests.cs

This PR includes the necessary DTO model, API client, and NUnit tests to cover the specified test scenario.

closes #1