### PR TITLE
Add C# autotests for GET /api/v1/donation/types endpoint

### DIFF
--- a/Clients/DonationTypesApiClient.cs
+++ b/Clients/DonationTypesApiClient.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class DonationTypesApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public DonationTypesApiClient(HttpClient httpClient, string baseUrl)
+    {
+        _httpClient = httpClient;
+        _baseUrl = baseUrl;
+    }
+
+    public async Task<ApiResponse<List<DonationTypeDto>>> GetDonationTypesAsync()
+    {
+        var response = await _httpClient.GetAsync($"{_baseUrl}/api/v1/donation/types");
+        var content = await response.Content.ReadAsStringAsync();
+
+        if (response.IsSuccessStatusCode)
+        {
+            var donationTypes = JsonSerializer.Deserialize<List<DonationTypeDto>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<DonationTypeDto>>
+            {
+                Data = donationTypes,
+                StatusCode = (int)response.StatusCode
+            };
+        }
+        else
+        {
+            var errorContent = JsonSerializer.Deserialize<ContentResult>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<DonationTypeDto>>
+            {
+                Error = errorContent,
+                StatusCode = (int)response.StatusCode
+            };
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public T Data { get; set; }
+    public ContentResult Error { get; set; }
+    public int StatusCode { get; set; }
+}

--- a/Models/DonationTypeDto.cs
+++ b/Models/DonationTypeDto.cs
@@ -1,0 +1,15 @@
+using System;
+
+public class DonationTypeDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string ShortDescription { get; set; }
+    public string LongDescription { get; set; }
+    public string IconData { get; set; }
+    public DateTime CreateDate { get; set; }
+    public string CreatedBy { get; set; }
+    public DateTime UpdateDate { get; set; }
+    public string LastUpdatedBy { get; set; }
+    public string HeaderColor { get; set; }
+}

--- a/Tests/DonationTypesApiTests.cs
+++ b/Tests/DonationTypesApiTests.cs
@@ -1,0 +1,65 @@
+using NUnit.Framework;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class DonationTypesApiTests
+{
+    private DonationTypesApiClient _client;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _client = new DonationTypesApiClient(httpClient, BaseUrl);
+    }
+
+    [Test]
+    public async Task GetDonationTypes_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+
+        // Act
+        var response = await _client.GetDonationTypesAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeOfType<List<DonationTypeDto>>();
+        response.Data.Should().NotBeEmpty();
+
+        // Additional assertions for the first item in the list
+        var firstDonationType = response.Data[0];
+        firstDonationType.Id.Should().BeGreaterThan(0);
+        firstDonationType.Name.Should().NotBeNullOrEmpty();
+        firstDonationType.CreateDate.Should().BeBefore(DateTime.UtcNow);
+        firstDonationType.UpdateDate.Should().BeBefore(DateTime.UtcNow);
+    }
+
+    [Test]
+    public async Task GetDonationTypes_ReturnsInternalServerError()
+    {
+        // Arrange
+        // You might need to mock the HttpClient to simulate a 500 error
+        // For this example, we'll assume the API might return a 500 error
+
+        // Act
+        var response = await _client.GetDonationTypesAsync();
+
+        // Assert
+        if (response.StatusCode == 500)
+        {
+            response.Error.Should().NotBeNull();
+            response.Error.StatusCode.Should().Be(500);
+            response.Error.Content.Should().NotBeNullOrEmpty();
+        }
+        else
+        {
+            // If we don't get a 500 error, the test should be inconclusive
+            Assert.Inconclusive("Expected 500 Internal Server Error was not received.");
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added DonationTypeDto model
- Added DonationTypesApiClient for interacting with the endpoint
- Added DonationTypesApiTests for testing the endpoint

closes #<issue_number>