### PR TITLE
Add DTO model, API client, and NUnit tests for PushNotificationCategory endpoint

### DIFF
--- a/Clients/FirebaseApiClient.cs
+++ b/Clients/FirebaseApiClient.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class FirebaseApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public FirebaseApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<ContentResult>> CreatePushNotificationCategoryAsync(PushNotificationCategoryDto category)
+    {
+        var json = JsonConvert.SerializeObject(category);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PostAsync("/api/v1/PushNotificationCategory", content);
+        return await ProcessResponseAsync<ContentResult>(response);
+    }
+
+    public async Task<ApiResponse<ContentResult>> EditPushNotificationCategoryAsync(PushNotificationCategoryDto category)
+    {
+        var json = JsonConvert.SerializeObject(category);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PutAsync("/api/v1/PushNotificationCategory", content);
+        return await ProcessResponseAsync<ContentResult>(response);
+    }
+
+    private async Task<ApiResponse<T>> ProcessResponseAsync<T>(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        var result = new ApiResponse<T>
+        {
+            StatusCode = (int)response.StatusCode,
+            IsSuccessStatusCode = response.IsSuccessStatusCode
+        };
+
+        if (response.IsSuccessStatusCode)
+        {
+            result.Data = JsonConvert.DeserializeObject<T>(content);
+        }
+        else
+        {
+            result.ErrorContent = content;
+        }
+
+        return result;
+    }
+}
+
+public class ApiResponse<T>
+{
+    public int StatusCode { get; set; }
+    public bool IsSuccessStatusCode { get; set; }
+    public T Data { get; set; }
+    public string ErrorContent { get; set; }
+}

--- a/Models/PushNotificationCategoryDto.cs
+++ b/Models/PushNotificationCategoryDto.cs
@@ -1,0 +1,6 @@
+public class PushNotificationCategoryDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+}

--- a/Tests/FirebaseApiTests.cs
+++ b/Tests/FirebaseApiTests.cs
@@ -1,0 +1,99 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class FirebaseApiTests
+{
+    private FirebaseApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _client = new FirebaseApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task CreatePushNotificationCategory_ValidData_ReturnsSuccessResult()
+    {
+        // Arrange
+        var category = new PushNotificationCategoryDto
+        {
+            Name = "Test Category",
+            Description = "This is a test category"
+        };
+
+        // Act
+        var response = await _client.CreatePushNotificationCategoryAsync(category);
+
+        // Assert
+        response.IsSuccessStatusCode.Should().BeTrue();
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.StatusCode.Should().Be(200);
+        response.Data.Content.Should().NotBeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task CreatePushNotificationCategory_InvalidData_ReturnsBadRequest()
+    {
+        // Arrange
+        var category = new PushNotificationCategoryDto
+        {
+            // Invalid data: missing Name
+            Description = "This is an invalid category"
+        };
+
+        // Act
+        var response = await _client.CreatePushNotificationCategoryAsync(category);
+
+        // Assert
+        response.IsSuccessStatusCode.Should().BeFalse();
+        response.StatusCode.Should().Be(400);
+        response.ErrorContent.Should().NotBeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task EditPushNotificationCategory_ValidData_ReturnsSuccessResult()
+    {
+        // Arrange
+        var category = new PushNotificationCategoryDto
+        {
+            Id = 1, // Assuming this ID exists
+            Name = "Updated Category",
+            Description = "This is an updated category"
+        };
+
+        // Act
+        var response = await _client.EditPushNotificationCategoryAsync(category);
+
+        // Assert
+        response.IsSuccessStatusCode.Should().BeTrue();
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.StatusCode.Should().Be(200);
+        response.Data.Content.Should().NotBeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task EditPushNotificationCategory_InvalidData_ReturnsBadRequest()
+    {
+        // Arrange
+        var category = new PushNotificationCategoryDto
+        {
+            Id = -1, // Invalid ID
+            Name = "Invalid Category",
+            Description = "This is an invalid category"
+        };
+
+        // Act
+        var response = await _client.EditPushNotificationCategoryAsync(category);
+
+        // Assert
+        response.IsSuccessStatusCode.Should().BeFalse();
+        response.StatusCode.Should().Be(400);
+        response.ErrorContent.Should().NotBeNullOrEmpty();
+    }
+}


### PR DESCRIPTION
This PR includes the following changes:
- Added PushNotificationCategoryDto model
- Added FirebaseApiClient for handling PushNotificationCategory API calls
- Added FirebaseApiTests for testing PushNotificationCategory API calls

closes #<issue_number>