### PR TITLE
Add tests for API Push Notification Category PUT endpoint

### DIFF
--- a/Clients/FirebaseApiClient.cs
+++ b/Clients/FirebaseApiClient.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class FirebaseApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public FirebaseApiClient(string baseUrl)
+    {
+        _baseUrl = baseUrl;
+        _httpClient = new HttpClient();
+    }
+
+    public async Task<ContentResult> EditPushNotificationCategoryAsync(PushNotificationCategoryDto category)
+    {
+        var json = JsonConvert.SerializeObject(category);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PutAsync($"{_baseUrl}/api/v1/PushNotificationCategory", content);
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var contentResult = JsonConvert.DeserializeObject<ContentResult>(responseContent);
+
+        if (contentResult == null)
+        {
+            contentResult = new ContentResult
+            {
+                Content = responseContent,
+                StatusCode = (int)response.StatusCode
+            };
+        }
+
+        return contentResult;
+    }
+}

--- a/Models/PushNotificationCategoryDto.cs
+++ b/Models/PushNotificationCategoryDto.cs
@@ -1,0 +1,14 @@
+using System;
+
+public class PushNotificationCategoryDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Picture { get; set; }
+    public int PushNotificationsCount { get; set; }
+    public string CreatedById { get; set; }
+    public string LastUpdatedById { get; set; }
+    public DateTime Created { get; set; }
+    public DateTime Updated { get; set; }
+    public bool IsDisabled { get; set; }
+}

--- a/Tests/FirebaseApiTests.cs
+++ b/Tests/FirebaseApiTests.cs
@@ -1,0 +1,94 @@
+using System;
+using NUnit.Framework;
+using FluentAssertions;
+using System.Threading.Tasks;
+
+[TestFixture]
+public class FirebaseApiTests
+{
+    private FirebaseApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        _client = new FirebaseApiClient("https://api.example.com"); // Replace with actual base URL
+    }
+
+    [Test]
+    public async Task EditPushNotificationCategory_ValidData_ReturnsSuccessResult()
+    {
+        // Arrange
+        var category = new PushNotificationCategoryDto
+        {
+            Id = 1,
+            Name = "Test Category",
+            Picture = "https://example.com/image.jpg",
+            PushNotificationsCount = 5,
+            CreatedById = "user1",
+            LastUpdatedById = "user2",
+            Created = DateTime.UtcNow.AddDays(-1),
+            Updated = DateTime.UtcNow,
+            IsDisabled = false
+        };
+
+        // Act
+        var result = await _client.EditPushNotificationCategoryAsync(category);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.StatusCode.Should().Be(200);
+        result.Content.Should().NotBeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task EditPushNotificationCategory_InvalidData_ReturnsBadRequestResult()
+    {
+        // Arrange
+        var category = new PushNotificationCategoryDto
+        {
+            Id = -1, // Invalid ID
+            Name = "", // Empty name
+            Picture = "not a valid url",
+            PushNotificationsCount = -5, // Negative count
+            CreatedById = null,
+            LastUpdatedById = null,
+            Created = DateTime.UtcNow.AddDays(1), // Future date
+            Updated = DateTime.UtcNow.AddDays(-1), // Past date
+            IsDisabled = false
+        };
+
+        // Act
+        var result = await _client.EditPushNotificationCategoryAsync(category);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.StatusCode.Should().Be(400);
+        result.Content.Should().Contain("Bad request");
+    }
+
+    [Test]
+    public async Task EditPushNotificationCategory_ServerError_ReturnsInternalServerErrorResult()
+    {
+        // Arrange
+        var category = new PushNotificationCategoryDto
+        {
+            Id = 999999, // Assuming this ID causes a server error
+            Name = "Error Category",
+            Picture = "https://example.com/error.jpg",
+            PushNotificationsCount = 0,
+            CreatedById = "user1",
+            LastUpdatedById = "user1",
+            Created = DateTime.UtcNow,
+            Updated = DateTime.UtcNow,
+            IsDisabled = true
+        };
+
+        // Act
+        var result = await _client.EditPushNotificationCategoryAsync(category);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.StatusCode.Should().Be(500);
+        result.Content.Should().Contain("Internal server error");
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:
- Added PushNotificationCategoryDto model
- Added FirebaseApiClient for handling PUT requests to /api/v1/PushNotificationCategory
- Added FirebaseApiTests for testing the PUT endpoint

closes #<issue_number>