### PR TITLE
Add C# autotests for QuickComments API endpoint

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public QuickCommentApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        var response = await _httpClient.PostAsync($"/api/v1/QuickComments?quickCommentCategory={category}", null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            var quickComments = JsonConvert.DeserializeObject<List<QuickCommentDto>>(content);
+            return new ApiResponse<List<QuickCommentDto>>(quickComments, (int)response.StatusCode);
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            var errorResult = JsonConvert.DeserializeObject<ContentResult>(errorContent);
+            return new ApiResponse<List<QuickCommentDto>>(null, errorResult.StatusCode, errorResult.Content);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public T Data { get; }
+    public int StatusCode { get; }
+    public string ErrorMessage { get; }
+
+    public ApiResponse(T data, int statusCode, string errorMessage = null)
+    {
+        Data = data;
+        StatusCode = statusCode;
+        ErrorMessage = errorMessage;
+    }
+}

--- a/Models/QuickCommentCategory.cs
+++ b/Models/QuickCommentCategory.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceComment = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Tests/QuickCommentApiTests.cs
+++ b/Tests/QuickCommentApiTests.cs
@@ -1,0 +1,69 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using System.Linq;
+
+[TestFixture]
+public class QuickCommentApiTests
+{
+    private QuickCommentApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        var httpClient = new HttpClient();
+        _client = new QuickCommentApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task GetQuickComments_ReasonForCancellation_ReturnsValidResponse()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().AllBeOfType<QuickCommentDto>();
+        response.Data.Should().NotBeEmpty();
+        response.Data.Should().OnlyContain(q => q.Id > 0);
+        response.Data.Should().OnlyContain(q => !string.IsNullOrEmpty(q.Comment));
+    }
+
+    [Test]
+    public async Task GetQuickComments_ExperienceComment_ReturnsValidResponse()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ExperienceComment;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().AllBeOfType<QuickCommentDto>();
+        response.Data.Should().NotBeEmpty();
+        response.Data.Should().OnlyContain(q => q.Id > 0);
+        response.Data.Should().OnlyContain(q => !string.IsNullOrEmpty(q.Comment));
+    }
+
+    [Test]
+    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
+    {
+        // Arrange
+        var category = (QuickCommentCategory)999; // Invalid category
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(400);
+        response.Data.Should().BeNull();
+        response.ErrorMessage.Should().NotBeNullOrEmpty();
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:
- Added DTO models for QuickCommentCategory and QuickCommentDto
- Created API client for QuickComments endpoint
- Added NUnit tests for QuickComments endpoint

Files added:
- Models/QuickCommentCategory.cs
- Models/QuickCommentDto.cs
- Clients/QuickCommentApiClient.cs
- Tests/QuickCommentApiTests.cs

closes #autotest_api_qc_post_001_v5