### PR TITLE
Add DTO models, API client, and NUnit tests for QuickComments endpoint

### DIFF
--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public QuickCommentApiClient(string baseUrl)
+    {
+        _baseUrl = baseUrl;
+        _httpClient = new HttpClient();
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        var url = $"{_baseUrl}/api/v1/QuickComments?quickCommentCategory={(int)category}";
+        var response = await _httpClient.PostAsync(url, null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            var quickComments = JsonSerializer.Deserialize<List<QuickCommentDto>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<QuickCommentDto>>(quickComments, (int)response.StatusCode);
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            var errorResult = JsonSerializer.Deserialize<ContentResult>(errorContent, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<QuickCommentDto>>(null, errorResult.StatusCode, errorResult.Content);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public T Data { get; }
+    public int StatusCode { get; }
+    public string ErrorMessage { get; }
+
+    public ApiResponse(T data, int statusCode, string errorMessage = null)
+    {
+        Data = data;
+        StatusCode = statusCode;
+        ErrorMessage = errorMessage;
+    }
+}

--- a/Models/QuickCommentCategoryDto.cs
+++ b/Models/QuickCommentCategoryDto.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceOfDonation = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Tests/QuickCommentApiTests.cs
+++ b/Tests/QuickCommentApiTests.cs
@@ -1,0 +1,73 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class QuickCommentApiTests
+{
+    private QuickCommentApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        _client = new QuickCommentApiClient("https://api-base-url.com");
+    }
+
+    [Test]
+    public async Task GetQuickComments_ReasonForCancellation_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeOfType<List<QuickCommentDto>>();
+        response.Data.Should().NotBeEmpty();
+        response.Data.ForEach(comment =>
+        {
+            comment.Id.Should().BeGreaterThan(0);
+            comment.Comment.Should().NotBeNullOrEmpty();
+        });
+    }
+
+    [Test]
+    public async Task GetQuickComments_ExperienceOfDonation_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ExperienceOfDonation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeOfType<List<QuickCommentDto>>();
+        response.Data.Should().NotBeEmpty();
+        response.Data.ForEach(comment =>
+        {
+            comment.Id.Should().BeGreaterThan(0);
+            comment.Comment.Should().NotBeNullOrEmpty();
+        });
+    }
+
+    [Test]
+    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
+    {
+        // Arrange
+        var category = (QuickCommentCategory)999; // Invalid category
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(400);
+        response.Data.Should().BeNull();
+        response.ErrorMessage.Should().NotBeNullOrEmpty();
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:
- Added QuickCommentCategoryDto.cs
- Added QuickCommentDto.cs
- Added QuickCommentApiClient.cs
- Added QuickCommentApiTests.cs

These changes cover the functionality for the /api/v1/QuickComments endpoint as described in the provided Swagger JSON fragment.
