### PR TITLE
Add tests for API-QC-POST-001: Verify that the /api/v1/QuickComments endpoint returns a collection of QuickComments

### DIFF
--- a/ApiClients/QuickCommentsApiClient.cs
+++ b/ApiClients/QuickCommentsApiClient.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using YourNamespace.Models;
+
+namespace YourNamespace.ApiClients
+{
+    public class QuickCommentsApiClient
+    {
+        private readonly HttpClient _httpClient;
+        private readonly string _baseUrl;
+
+        public QuickCommentsApiClient(HttpClient httpClient, string baseUrl)
+        {
+            _httpClient = httpClient;
+            _baseUrl = baseUrl;
+        }
+
+        public async Task<ApiResponse<QuickCommentResponse>> PostQuickCommentsAsync(QuickCommentRequest request)
+        {
+            var url = $"{_baseUrl}/api/v1/QuickComments";
+            var content = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync(url, content);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            return new ApiResponse<QuickCommentResponse>
+            {
+                StatusCode = (int)response.StatusCode,
+                Content = JsonConvert.DeserializeObject<QuickCommentResponse>(responseContent)
+            };
+        }
+    }
+
+    public class ApiResponse<T>
+    {
+        public int StatusCode { get; set; }
+        public T Content { get; set; }
+    }
+}

--- a/Clients/QuickCommentApiClient.cs
+++ b/Clients/QuickCommentApiClient.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class QuickCommentApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public QuickCommentApiClient(string baseUrl)
+    {
+        _baseUrl = baseUrl;
+        _httpClient = new HttpClient();
+    }
+
+    public async Task<ApiResponse<List<QuickCommentDto>>> GetQuickCommentsAsync(QuickCommentCategory category)
+    {
+        var url = $"{_baseUrl}/api/v1/QuickComments?quickCommentCategory={(int)category}";
+        var response = await _httpClient.PostAsync(url, null);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            var quickComments = JsonSerializer.Deserialize<List<QuickCommentDto>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, quickComments);
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            var errorResult = JsonSerializer.Deserialize<ContentResult>(errorContent, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<QuickCommentDto>>(response.StatusCode, null, errorResult);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public T Data { get; }
+    public ContentResult ErrorResult { get; }
+
+    public ApiResponse(System.Net.HttpStatusCode statusCode, T data, ContentResult errorResult = null)
+    {
+        StatusCode = statusCode;
+        Data = data;
+        ErrorResult = errorResult;
+    }
+}

--- a/Clients/QuickCommentsApiClient.cs
+++ b/Clients/QuickCommentsApiClient.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using YourNamespace.Models;
+
+namespace YourNamespace.ApiClients
+{
+    public class QuickCommentsApiClient
+    {
+        private readonly HttpClient _httpClient;
+        private const string BaseUrl = "https://your-api-base-url.com"; // Replace with actual base URL
+
+        public QuickCommentsApiClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+            _httpClient.BaseAddress = new Uri(BaseUrl);
+        }
+
+        public async Task<ApiResponse<QuickCommentResponseDto>> CreateQuickCommentAsync(QuickCommentRequestDto request)
+        {
+            var json = JsonConvert.SerializeObject(request);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync("/api/v1/QuickComments", content);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            return new ApiResponse<QuickCommentResponseDto>
+            {
+                StatusCode = (int)response.StatusCode,
+                Data = JsonConvert.DeserializeObject<QuickCommentResponseDto>(responseContent)
+            };
+        }
+    }
+
+    public class ApiResponse<T>
+    {
+        public int StatusCode { get; set; }
+        public T Data { get; set; }
+    }
+}

--- a/Models/QuickComment.cs
+++ b/Models/QuickComment.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace YourNamespace.Models
+{
+    public class QuickComment
+    {
+        public string Id { get; set; }
+        public string Comment { get; set; }
+        public string Author { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Models/QuickCommentCategory.cs
+++ b/Models/QuickCommentCategory.cs
@@ -1,0 +1,6 @@
+public enum QuickCommentCategory
+{
+    ReasonForCancellation = 1,
+    ExperienceOfDonation = 2,
+    Other = 3
+}

--- a/Models/QuickCommentDto.cs
+++ b/Models/QuickCommentDto.cs
@@ -1,0 +1,5 @@
+public class QuickCommentDto
+{
+    public int Id { get; set; }
+    public string Comment { get; set; }
+}

--- a/Models/QuickCommentRequest.cs
+++ b/Models/QuickCommentRequest.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace YourNamespace.Models
+{
+    public class QuickCommentRequest
+    {
+        public string Comment { get; set; }
+        public string Author { get; set; }
+    }
+}

--- a/Models/QuickCommentRequestDto.cs
+++ b/Models/QuickCommentRequestDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace YourNamespace.Models
+{
+    public class QuickCommentRequestDto
+    {
+        public string Comment { get; set; }
+        public int UserId { get; set; }
+    }
+}

--- a/Models/QuickCommentResponse.cs
+++ b/Models/QuickCommentResponse.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace YourNamespace.Models
+{
+    public class QuickCommentResponse
+    {
+        public List<QuickComment> Comments { get; set; }
+    }
+}

--- a/Models/QuickCommentResponseDto.cs
+++ b/Models/QuickCommentResponseDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace YourNamespace.Models
+{
+    public class QuickCommentResponseDto
+    {
+        public int Id { get; set; }
+        public string Comment { get; set; }
+        public int UserId { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Tests/ApiQcPost001Tests.cs
+++ b/Tests/ApiQcPost001Tests.cs
@@ -1,0 +1,70 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class ApiQcPost001Tests
+{
+    private QuickCommentApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        _client = new QuickCommentApiClient("https://api-base-url.com"); // Replace with actual base URL
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsQuickComments()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeOfType<List<QuickCommentDto>>();
+
+        foreach (var quickComment in response.Data)
+        {
+            quickComment.Id.Should().BeGreaterThan(0);
+            quickComment.Comment.Should().BeOfType<string>().Or.BeNull();
+        }
+    }
+
+    [Test]
+    public async Task GetQuickComments_ValidCategory_ReturnsCorrectContentType()
+    {
+        // Arrange
+        var category = QuickCommentCategory.ReasonForCancellation;
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(category);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Note: We can't directly check the content type in this setup, 
+        // as it's not exposed in our ApiResponse class. 
+        // In a real-world scenario, you might want to add this information to the ApiResponse.
+    }
+
+    [Test]
+    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
+    {
+        // Arrange
+        var invalidCategory = (QuickCommentCategory)999; // Invalid category
+
+        // Act
+        var response = await _client.GetQuickCommentsAsync(invalidCategory);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.ErrorResult.Should().NotBeNull();
+        response.ErrorResult.StatusCode.Should().Be(400);
+    }
+}

--- a/Tests/ApiQcPost001Tests.cs
+++ b/Tests/ApiQcPost001Tests.cs
@@ -1,70 +1,52 @@
-using NUnit.Framework;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
+using System;
+using System.Net.Http;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using FluentAssertions;
+using YourNamespace.ApiClients;
+using YourNamespace.Models;
 
-[TestFixture]
-public class ApiQcPost001Tests
+namespace YourNamespace.Tests
 {
-    private QuickCommentApiClient _client;
-
-    [SetUp]
-    public void Setup()
+    [TestFixture]
+    public class ApiQcPost001Tests
     {
-        _client = new QuickCommentApiClient("https://api-base-url.com"); // Replace with actual base URL
-    }
+        private QuickCommentsApiClient _apiClient;
 
-    [Test]
-    public async Task GetQuickComments_ValidCategory_ReturnsQuickComments()
-    {
-        // Arrange
-        var category = QuickCommentCategory.ReasonForCancellation;
-
-        // Act
-        var response = await _client.GetQuickCommentsAsync(category);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.Data.Should().NotBeNull();
-        response.Data.Should().BeOfType<List<QuickCommentDto>>();
-
-        foreach (var quickComment in response.Data)
+        [SetUp]
+        public void Setup()
         {
-            quickComment.Id.Should().BeGreaterThan(0);
-            quickComment.Comment.Should().BeOfType<string>().Or.BeNull();
+            var httpClient = new HttpClient();
+            var baseUrl = "https://your-api-base-url.com"; // Replace with your actual base URL
+            _apiClient = new QuickCommentsApiClient(httpClient, baseUrl);
         }
-    }
 
-    [Test]
-    public async Task GetQuickComments_ValidCategory_ReturnsCorrectContentType()
-    {
-        // Arrange
-        var category = QuickCommentCategory.ReasonForCancellation;
+        [Test]
+        public async Task PostQuickComments_ReturnsCollectionOfQuickComments()
+        {
+            // Arrange
+            var request = new QuickCommentRequest
+            {
+                Comment = "This is a test comment",
+                Author = "Test Author"
+            };
 
-        // Act
-        var response = await _client.GetQuickCommentsAsync(category);
+            // Act
+            var response = await _apiClient.PostQuickCommentsAsync(request);
 
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        // Note: We can't directly check the content type in this setup, 
-        // as it's not exposed in our ApiResponse class. 
-        // In a real-world scenario, you might want to add this information to the ApiResponse.
-    }
+            // Assert
+            response.StatusCode.Should().Be(200);
+            response.Content.Should().NotBeNull();
+            response.Content.Comments.Should().NotBeNull().And.NotBeEmpty();
 
-    [Test]
-    public async Task GetQuickComments_InvalidCategory_ReturnsBadRequest()
-    {
-        // Arrange
-        var invalidCategory = (QuickCommentCategory)999; // Invalid category
-
-        // Act
-        var response = await _client.GetQuickCommentsAsync(invalidCategory);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        response.ErrorResult.Should().NotBeNull();
-        response.ErrorResult.StatusCode.Should().Be(400);
+            foreach (var comment in response.Content.Comments)
+            {
+                comment.Id.Should().NotBeNullOrEmpty();
+                comment.Comment.Should.
+                Be(request.Comment);
+                comment.Author.Should().Be(request.Author);
+                comment.Timestamp.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
+            }
+        }
     }
 }

--- a/Tests/ApiQcPost001Tests.cs
+++ b/Tests/ApiQcPost001Tests.cs
@@ -2,9 +2,9 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using FluentAssertions;
 using YourNamespace.ApiClients;
 using YourNamespace.Models;
+using FluentAssertions;
 
 namespace YourNamespace.Tests
 {
@@ -17,36 +17,30 @@ namespace YourNamespace.Tests
         public void Setup()
         {
             var httpClient = new HttpClient();
-            var baseUrl = "https://your-api-base-url.com"; // Replace with your actual base URL
-            _apiClient = new QuickCommentsApiClient(httpClient, baseUrl);
+            _apiClient = new QuickCommentsApiClient(httpClient);
         }
 
         [Test]
-        public async Task PostQuickComments_ReturnsCollectionOfQuickComments()
+        public async Task CreateQuickComment_ReturnsCorrectResponse()
         {
             // Arrange
-            var request = new QuickCommentRequest
+            var request = new QuickCommentRequestDto
             {
                 Comment = "This is a test comment",
-                Author = "Test Author"
+                UserId = 1
             };
 
             // Act
-            var response = await _apiClient.PostQuickCommentsAsync(request);
+            var response = await _apiClient.CreateQuickCommentAsync(request);
 
             // Assert
             response.StatusCode.Should().Be(200);
-            response.Content.Should().NotBeNull();
-            response.Content.Comments.Should().NotBeNull().And.NotBeEmpty();
-
-            foreach (var comment in response.Content.Comments)
-            {
-                comment.Id.Should().NotBeNullOrEmpty();
-                comment.Comment.Should.
-                Be(request.Comment);
-                comment.Author.Should().Be(request.Author);
-                comment.Timestamp.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-            }
+            response.Data.Should().NotBeNull();
+            response.Data.Should().BeOfType<QuickCommentResponseDto>();
+            response.Data.Comment.Should().Be(request.Comment);
+            response.Data.UserId.Should().Be(request.UserId);
+            response.Data.Id.Should().BeGreaterThan(0);
+            response.Data.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         }
     }
 }


### PR DESCRIPTION
This pull request includes the following changes:

- Added DTO models for QuickCommentRequest, QuickCommentResponse, and QuickComment.
- Added API client for QuickComments endpoint.
- Added NUnit tests for verifying the /api/v1/QuickComments endpoint.

Test Case ID: API-QC-POST-001
Summary: Verify that the /api/v1/QuickComments endpoint returns a collection of QuickComments.