### PR TITLE
Add API client and NUnit tests for TC-/api/v1/badge GET

### DIFF
--- a/Clients/ApiClient.cs
+++ b/Clients/ApiClient.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class ApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public ApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<BadgeDto>> GetBadgeAsync()
+    {
+        var response = await _httpClient.GetAsync("/api/v1/badge");
+        var content = await response.Content.ReadAsStringAsync();
+
+        if (response.IsSuccessStatusCode)
+        {
+            var badge = JsonConvert.DeserializeObject<BadgeDto>(content);
+            return new ApiResponse<BadgeDto>(badge, response.StatusCode);
+        }
+        else
+        {
+            var errorContent = JsonConvert.DeserializeObject<ContentResult>(content);
+            return new ApiResponse<BadgeDto>(null, response.StatusCode, errorContent);
+        }
+    }
+}
+
+public class ApiResponse<T>
+{
+    public T Data { get; }
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public ContentResult ErrorContent { get; }
+
+    public ApiResponse(T data, System.Net.HttpStatusCode statusCode, ContentResult errorContent = null)
+    {
+        Data = data;
+        StatusCode = statusCode;
+        ErrorContent = errorContent;
+    }
+}

--- a/Tests/ApiDnGet134Tests.cs
+++ b/Tests/ApiDnGet134Tests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+
+[TestFixture]
+public class ApiDnGet134Tests
+{
+    private ApiClient _apiClient;
+    private Mock<HttpMessageHandler> _mockHttpMessageHandler;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        var client = new HttpClient(_mockHttpMessageHandler.Object);
+        _apiClient = new ApiClient(client);
+    }
+
+    [Test]
+    public async Task GetBadge_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+        var expectedBadge = new BadgeDto
+        {
+            Id = 1,
+            Name = "Test Badge",
+            Description = "This is a test badge",
+            Picture = "https://example.com/badge.png",
+            CreateDate = DateTime.UtcNow.AddDays(-1),
+            CreatedBy = "TestUser",
+            UpdateDate = DateTime.UtcNow,
+            LastUpdatedBy = "TestUser"
+        };
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(expectedBadge))
+            });
+
+        // Act
+        var response = await _apiClient.GetBadgeAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeEquivalentTo(expectedBadge);
+    }
+
+    [Test]
+    public async Task GetBadge_ReturnsBadRequest()
+    {
+        // Arrange
+        var errorContent = new ContentResult
+        {
+            Content = "Invalid request",
+            ContentType = "application/json",
+            StatusCode = 400
+        };
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(errorContent))
+            });
+
+        // Act
+        var response = await _apiClient.GetBadgeAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Data.Should().BeNull();
+        response.ErrorContent.Should().NotBeNull();
+        response.ErrorContent.Should().BeEquivalentTo(errorContent);
+    }
+
+    [Test]
+    public async Task GetBadge_ReturnsInternalServerError()
+    {
+        // Arrange
+        var errorContent = new ContentResult
+        {
+            Content = "Internal server error",
+            ContentType = "application/json",
+            StatusCode = 500
+        };
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.InternalServerError,
+                Content = new StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(errorContent))
+            });
+
+        // Act
+        var response = await _apiClient.GetBadgeAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        response.Data.Should().BeNull();
+        response.ErrorContent.Should().NotBeNull();
+        response.ErrorContent.Should().BeEquivalentTo(errorContent);
+    }
+}


### PR DESCRIPTION
### Jira Key: AT-134

This pull request includes the following changes:

- **API Client**: Added `ApiClient.cs` to handle the `/api/v1/badge` GET endpoint.
- **NUnit Tests**: Added `ApiDnGet134Tests.cs` to cover the test scenarios for the `/api/v1/badge` GET endpoint.

#### Files Added:
- `Clients/ApiClient.cs`
- `Tests/ApiDnGet134Tests.cs`

#### Test Scenarios Covered:
1. Successful retrieval of badge.
2. Handling of bad request response.
3. Handling of internal server error response.

[View Issue](https://taa-test-project.atlassian.net/browse/AT-134)