### PR TITLE
Add API client and NUnit tests for AT-142: Validate successful retrieval of badges list

### DIFF
--- a/Clients/BadgeApiClient.cs
+++ b/Clients/BadgeApiClient.cs
@@ -1,64 +1,46 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
-
-public class ApiResponse<T>
-{
-    public T Data { get; set; }
-    public int StatusCode { get; set; }
-    public string ErrorMessage { get; set; }
-}
 
 public class BadgeApiClient
 {
     private readonly HttpClient _httpClient;
-    private readonly string _baseUrl;
-    private bool _simulateError;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
 
-    public BadgeApiClient(HttpClient httpClient, string baseUrl)
+    public BadgeApiClient(HttpClient httpClient)
     {
         _httpClient = httpClient;
-        _baseUrl = baseUrl;
-    }
-
-    public void SimulateError(bool simulate)
-    {
-        _simulateError = simulate;
+        _httpClient.BaseAddress = new Uri(BaseUrl);
     }
 
     public async Task<ApiResponse<List<BadgeDto>>> GetBadgesAsync()
     {
-        if (_simulateError)
-        {
-            return new ApiResponse<List<BadgeDto>>
-            {
-                StatusCode = 500,
-                ErrorMessage = "Simulated Internal Server Error"
-            };
-        }
-
-        var response = await _httpClient.GetAsync(`${_baseUrl}/api/v1/badges`);
-        var statusCode = (int)response.StatusCode;
+        var response = await _httpClient.GetAsync("/api/v1/badges");
+        var content = await response.Content.ReadAsStringAsync();
 
         if (response.IsSuccessStatusCode)
         {
-            var badges = await response.Content.ReadFromJsonAsync<List<BadgeDto>>();
-            return new ApiResponse<List<BadgeDto>>
-            {
-                Data = badges,
-                StatusCode = statusCode
-            };
+            var badges = JsonSerializer.Deserialize<List<BadgeDto>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return new ApiResponse<List<BadgeDto>>(badges, response.StatusCode);
         }
-        else
-        {
-            var errorContent = await response.Content.ReadFromJsonAsync<ContentResult>();
-            return new ApiResponse<List<BadgeDto>>
-            {
-                StatusCode = statusCode,
-                ErrorMessage = errorContent?.Content
-            };
-        }
+
+        var errorResult = JsonSerializer.Deserialize<ContentResult>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return new ApiResponse<List<BadgeDto>>(null, response.StatusCode, errorResult);
+    }
+}
+
+public class ApiResponse<T>
+{
+    public T Data { get; }
+    public System.Net.HttpStatusCode StatusCode { get; }
+    public ContentResult ErrorResult { get; }
+
+    public ApiResponse(T data, System.Net.HttpStatusCode statusCode, ContentResult errorResult = null)
+    {
+        Data = data;
+        StatusCode = statusCode;
+        ErrorResult = errorResult;
     }
 }

--- a/Tests/ApiDnGet001Tests.cs
+++ b/Tests/ApiDnGet001Tests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+
+[TestFixture]
+public class ApiDnGet001Tests
+{
+    private BadgeApiClient _client;
+    private Mock<HttpMessageHandler> _mockHttpMessageHandler;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        var httpClient = new HttpClient(_mockHttpMessageHandler.Object);
+        _client = new BadgeApiClient(httpClient);
+    }
+
+    [Test]
+    public async Task GetBadges_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+        var expectedBadges = new List<BadgeDto>
+        {
+            new BadgeDto
+            {
+                Id = 1,
+                Name = "Test Badge",
+                Description = "Test Description",
+                Picture = "test.jpg",
+                CreateDate = DateTime.UtcNow,
+                CreatedBy = "TestUser",
+                UpdateDate = DateTime.UtcNow,
+                LastUpdatedBy = "TestUser"
+            }
+        };
+
+        var jsonResponse = JsonSerializer.Serialize(expectedBadges);
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(jsonResponse)
+            });
+
+        // Act
+        var response = await _client.GetBadgesAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().HaveCount(1);
+        response.Data[0].Should().BeEquivalentTo(expectedBadges[0]);
+    }
+
+    [Test]
+    public async Task GetBadges_ReturnsEmptyList()
+    {
+        // Arrange
+        var emptyList = new List<BadgeDto>();
+        var jsonResponse = JsonSerializer.Serialize(emptyList);
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(jsonResponse)
+            });
+
+        // Act
+        var response = await _client.GetBadgesAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GetBadges_ReturnsBadRequest()
+    {
+        // Arrange
+        var errorContent = new ContentResult
+        {
+            Content = "Bad Request",
+            ContentType = "application/json",
+            StatusCode = 400
+        };
+
+        var jsonResponse = JsonSerializer.Serialize(errorContent);
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent(jsonResponse)
+            });
+
+        // Act
+        var response = await _client.GetBadgesAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Data.Should().BeNull();
+        response.ErrorResult.Should().NotBeNull();
+        response.ErrorResult.Should().BeEquivalentTo(errorContent);
+    }
+
+    [Test]
+    public async Task GetBadges_ReturnsInternalServerError()
+    {
+        // Arrange
+        var errorContent = new ContentResult
+        {
+            Content = "Internal Server Error",
+            ContentType = "application/json",
+            StatusCode = 500
+        };
+
+        var jsonResponse = JsonSerializer.Serialize(errorContent);
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.InternalServerError,
+                Content = new StringContent(jsonResponse)
+            });
+
+        // Act
+        var response = await _client.GetBadgesAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        response.Data.Should().BeNull();
+        response.ErrorResult.Should().NotBeNull();
+        response.ErrorResult.Should().BeEquivalentTo(errorContent);
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

1. **API Client**: Added `BadgeApiClient` to handle GET requests to `/api/v1/badges` endpoint.
2. **NUnit Tests**: Added `ApiDnGet001Tests` to validate the successful retrieval of badges list, handling of empty list, bad request, and internal server error responses.

Files added/modified:
- `Clients/BadgeApiClient.cs`
- `Tests/ApiDnGet001Tests.cs`

closes #142