### PR TITLE
Add DTO model, API client, and NUnit tests for AT-144

### DIFF
--- a/Clients/DonationTypesApiClient.cs
+++ b/Clients/DonationTypesApiClient.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using DonorApp.Services.DTO;
+using Newtonsoft.Json;
+
+namespace DonorApp.ApiClient
+{
+    public class DonationTypesApiClient
+    {
+        private readonly HttpClient _httpClient;
+        private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+        public DonationTypesApiClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+            _httpClient.BaseAddress = new Uri(BaseUrl);
+        }
+
+        public async Task<ApiResponse<List<DonationTypeDto>>> GetDonationTypesAsync()
+        {
+            var response = await _httpClient.GetAsync("/api/v1/donation/types");
+            return await CreateApiResponseAsync<List<DonationTypeDto>>(response);
+        }
+
+        public async Task<ApiResponse<ContentResult>> AddDonationTypeAsync(DonationTypeDto donationType)
+        {
+            var content = new StringContent(JsonConvert.SerializeObject(donationType), Encoding.UTF8, "application/json");
+            var response = await _httpClient.PostAsync("/api/v1/donation/types", content);
+            return await CreateApiResponseAsync<ContentResult>(response);
+        }
+
+        public async Task<ApiResponse<ContentResult>> EditDonationTypeAsync(DonationTypeDto donationType)
+        {
+            var content = new StringContent(JsonConvert.SerializeObject(donationType), Encoding.UTF8, "application/json");
+            var response = await _httpClient.PutAsync("/api/v1/donation/types", content);
+            return await CreateApiResponseAsync<ContentResult>(response);
+        }
+
+        private async Task<ApiResponse<T>> CreateApiResponseAsync<T>(HttpResponseMessage response)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            var result = new ApiResponse<T>
+            {
+                StatusCode = (int)response.StatusCode,
+                IsSuccessStatusCode = response.IsSuccessStatusCode
+            };
+
+            if (response.IsSuccessStatusCode)
+            {
+                result.Data = JsonConvert.DeserializeObject<T>(content);
+            }
+            else
+            {
+                result.Error = JsonConvert.DeserializeObject<ContentResult>(content);
+            }
+
+            return result;
+        }
+    }
+
+    public class ApiResponse<T>
+    {
+        public int StatusCode { get; set; }
+        public bool IsSuccessStatusCode { get; set; }
+        public T Data { get; set; }
+        public ContentResult Error { get; set; }
+    }
+}

--- a/Models/DonationTypeDto.cs
+++ b/Models/DonationTypeDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace DonorApp.Services.DTO
+{
+    public class DonationTypeDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        // Add other properties as needed
+    }
+}

--- a/Tests/ApiDnGet001Tests.cs
+++ b/Tests/ApiDnGet001Tests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using DonorApp.ApiClient;
+using DonorApp.Services.DTO;
+using NUnit.Framework;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+
+namespace DonorApp.Tests
+{
+    [TestFixture]
+    public class ApiDnGet001Tests
+    {
+        private DonationTypesApiClient _client;
+        private Mock<HttpMessageHandler> _mockHttpMessageHandler;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            var httpClient = new HttpClient(_mockHttpMessageHandler.Object);
+            _client = new DonationTypesApiClient(httpClient);
+        }
+
+        [Test]
+        public async Task AT_144_ValidateSuccessfulRetrievalOfAllDonationTypes()
+        {
+            // Arrange
+            var expectedDonationTypes = new List<DonationTypeDto>
+            {
+                new DonationTypeDto { Id = Guid.NewGuid(), Name = "Whole Blood", Description = "Standard blood donation" },
+                new DonationTypeDto { Id = Guid.NewGuid(), Name = "Plasma", Description = "Plasma only donation" }
+            };
+
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(expectedDonationTypes))
+                });
+
+            // Act
+            var response = await _client.GetDonationTypesAsync();
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+            response.IsSuccessStatusCode.Should().BeTrue();
+            response.Data.Should().NotBeNull();
+            response.Data.Should().HaveCount(2);
+            response.Data.Should().BeEquivalentTo(expectedDonationTypes);
+        }
+
+        [Test]
+        public async Task AT_145_ValidateErrorHandlingWhenAccessingWithServerIssues()
+        {
+            // Arrange
+            var expectedError = new ContentResult
+            {
+                Content = "Internal Server Error",
+                StatusCode = 500
+            };
+
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.InternalServerError,
+                    Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(expectedError))
+                });
+
+            // Act
+            var response = await _client.GetDonationTypesAsync();
+
+            // Assert
+            response.StatusCode.Should().Be(500);
+            response.IsSuccessStatusCode.Should().BeFalse();
+            response.Data.Should().BeNull();
+            response.Error.Should().NotBeNull();
+            response.Error.Should().BeEquivalentTo(expectedError);
+        }
+    }
+}


### PR DESCRIPTION
This PR includes the following changes:
- Added `DonationTypeDto` model
- Added `DonationTypesApiClient` for handling donation types API
- Added `ApiDnGet001Tests` for testing the GET /api/v1/donation/types endpoint

closes #144