### PR TITLE
Add tests for API-QC-POST-001: Verify that the /api/v1/QuickComments endpoint returns a collection of QuickComments

### DIFF
--- a/Clients/QuickCommentsApiClient.cs
+++ b/Clients/QuickCommentsApiClient.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using YourNamespace.Models;
+
+namespace YourNamespace.ApiClients
+{
+    public class QuickCommentsApiClient
+    {
+        private readonly HttpClient _httpClient;
+        private readonly string _baseUrl;
+
+        public QuickCommentsApiClient(HttpClient httpClient, string baseUrl)
+        {
+            _httpClient = httpClient;
+            _baseUrl = baseUrl;
+        }
+
+        public async Task<ApiResponse<List<QuickCommentResponseDto>>> PostQuickCommentsAsync(QuickCommentRequestDto request)
+        {
+            var url = $"{_baseUrl}/api/v1/QuickComments";
+            var content = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync(url, content);
+            var responseBody = await response.Content.ReadAsStringAsync();
+
+            return new ApiResponse<List<QuickCommentResponseDto>>
+            {
+                StatusCode = (int)response.StatusCode,
+                Data = JsonConvert.DeserializeObject<List<QuickCommentResponseDto>>(responseBody)
+            };
+        }
+    }
+
+    public class ApiResponse<T>
+    {
+        public int StatusCode { get; set; }
+        public T Data { get; set; }
+    }
+}

--- a/Models/QuickCommentRequestDto.cs
+++ b/Models/QuickCommentRequestDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace YourNamespace.Models
+{
+    public class QuickCommentRequestDto
+    {
+        public string Comment { get; set; }
+        public int UserId { get; set; }
+    }
+}

--- a/Models/QuickCommentResponseDto.cs
+++ b/Models/QuickCommentResponseDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace YourNamespace.Models
+{
+    public class QuickCommentResponseDto
+    {
+        public int Id { get; set; }
+        public string Comment { get; set; }
+        public int UserId { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Tests/ApiQcPost001Tests.cs
+++ b/Tests/ApiQcPost001Tests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using FluentAssertions;
+using YourNamespace.ApiClients;
+using YourNamespace.Models;
+
+namespace YourNamespace.Tests
+{
+    [TestFixture]
+    public class ApiQcPost001Tests
+    {
+        private QuickCommentsApiClient _apiClient;
+
+        [SetUp]
+        public void Setup()
+        {
+            var httpClient = new HttpClient();
+            var baseUrl = "https://your-api-base-url.com"; // Replace with your actual base URL
+            _apiClient = new QuickCommentsApiClient(httpClient, baseUrl);
+        }
+
+        [Test]
+        public async Task PostQuickComments_ReturnsCollectionOfQuickComments()
+        {
+            // Arrange
+            var request = new QuickCommentRequestDto
+            {
+                Comment = "Test comment",
+                UserId = 1
+            };
+
+            // Act
+            var response = await _apiClient.PostQuickCommentsAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+            response.Data.Should().NotBeNull();
+            response.Data.Should().BeAssignableTo<List<QuickCommentResponseDto>>();
+
+            foreach (var quickComment in response.Data)
+            {
+                quickComment.Id.Should().BeGreaterThan(0);
+                quickComment.Comment.Should().NotBeNullOrEmpty();
+                quickComment.UserId.Should().BeGreaterThan(0);
+                quickComment.Timestamp.Should().NotBe(default(DateTime));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added DTO models for QuickCommentRequest and QuickCommentResponse.
- Added API client for the /api/v1/QuickComments endpoint.
- Added NUnit tests for verifying the /api/v1/QuickComments endpoint.

Files added:
- Models/QuickCommentRequestDto.cs
- Models/QuickCommentResponseDto.cs
- Clients/QuickCommentsApiClient.cs
- Tests/ApiQcPost001Tests.cs

Test Case ID: API-QC-POST-001
Summary: Verify that the /api/v1/QuickComments endpoint returns a collection of QuickComments