### PR TITLE
Add DTO model, API client, and NUnit tests for AT-155 and AT-156

### DIFF
--- a/Clients/FirebaseApiClient.cs
+++ b/Clients/FirebaseApiClient.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class FirebaseApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public FirebaseApiClient(string baseUrl)
+    {
+        _baseUrl = baseUrl;
+        _httpClient = new HttpClient();
+    }
+
+    public async Task<ApiResponse<ContentResult>> CreatePushNotificationAsync(PushNotificationDto notification)
+    {
+        var json = JsonConvert.SerializeObject(notification);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PostAsync($"{_baseUrl}/api/v1/PushNotification", content);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return new ApiResponse<ContentResult>
+        {
+            StatusCode = (int)response.StatusCode,
+            Data = JsonConvert.DeserializeObject<ContentResult>(responseContent)
+        };
+    }
+
+    public async Task<ApiResponse<ContentResult>> EditPushNotificationAsync(PushNotificationDto notification)
+    {
+        var json = JsonConvert.SerializeObject(notification);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _httpClient.PutAsync($"{_baseUrl}/api/v1/PushNotification", content);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return new ApiResponse<ContentResult>
+        {
+            StatusCode = (int)response.StatusCode,
+            Data = JsonConvert.DeserializeObject<ContentResult>(responseContent)
+        };
+    }
+
+    public async Task<ApiResponse<ContentResult>> DeletePushNotificationAsync(int id)
+    {
+        var response = await _httpClient.DeleteAsync($"{_baseUrl}/api/v1/PushNotification?id={id}");
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return new ApiResponse<ContentResult>
+        {
+            StatusCode = (int)response.StatusCode,
+            Data = JsonConvert.DeserializeObject<ContentResult>(responseContent)
+        };
+    }
+}
+
+public class ApiResponse<T>
+{
+    public int StatusCode { get; set; }
+    public T Data { get; set; }
+}

--- a/Models/PushNotificationDto.cs
+++ b/Models/PushNotificationDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+public class PushNotificationDto
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Body { get; set; }
+    public string Topic { get; set; }
+    public DateTime? ScheduledTime { get; set; }
+}

--- a/Tests/PushNotificationApiTests.cs
+++ b/Tests/PushNotificationApiTests.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[TestFixture]
+public class PushNotificationApiTests
+{
+    private FirebaseApiClient _client;
+
+    [SetUp]
+    public void Setup()
+    {
+        _client = new FirebaseApiClient("https://api.example.com"); // Replace with actual base URL
+    }
+
+    [Test]
+    public async Task AT155_CreatePushNotification_SuccessfulCreation()
+    {
+        // Arrange
+        var notification = new PushNotificationDto
+        {
+            Title = "Test Notification",
+            Body = "This is a test notification",
+            Topic = "TestTopic",
+            ScheduledTime = DateTime.UtcNow.AddHours(1)
+        };
+
+        // Act
+        var response = await _client.CreatePushNotificationAsync(notification);
+
+        // Assert
+        response.StatusCode.Should().Be(200);
+        response.Data.Should().NotBeNull();
+        response.Data.Content.Should().NotBeNullOrEmpty();
+        response.Data.StatusCode.Should().Be(200);
+    }
+
+    [Test]
+    public async Task AT156_CreatePushNotification_InvalidPayload()
+    {
+        // Arrange
+        var invalidNotification = new PushNotificationDto
+        {
+            // Missing required fields
+        };
+
+        // Act
+        var response = await _client.CreatePushNotificationAsync(invalidNotification);
+
+        // Assert
+        response.StatusCode.Should().Be(400);
+        response.Data.Should().NotBeNull();
+        response.Data.Content.Should().Contain("Bad request");
+        response.Data.StatusCode.Should().Be(400);
+    }
+}


### PR DESCRIPTION
### Jira Issues
1. **AT-155**: [TC-/api/v1/PushNotification POST - Validate successful creation of a new Push Notification](https://taa-test-project.atlassian.net/browse/AT-155)
2. **AT-156**: [TC-/api/v1/PushNotification POST - Validate error response for invalid payload](https://taa-test-project.atlassian.net/browse/AT-156)

### Summary
This pull request includes the following changes:
- Added `PushNotificationDto` model in `Models/PushNotificationDto.cs`
- Added `FirebaseApiClient` in `Clients/FirebaseApiClient.cs` for handling Push Notification API calls
- Added NUnit tests in `Tests/PushNotificationApiTests.cs` to cover the scenarios mentioned in the Jira issues

### Files Changed
- `Models/PushNotificationDto.cs`
- `Clients/FirebaseApiClient.cs`
- `Tests/PushNotificationApiTests.cs`