### PR TITLE
Add tests for /api/v1/user/badges endpoint

### DIFF
--- a/Clients/UserBadgesApiClient.cs
+++ b/Clients/UserBadgesApiClient.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+public class UserBadgesApiClient
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://api.example.com"; // Replace with actual base URL
+
+    public UserBadgesApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+    }
+
+    public async Task<ApiResponse<List<BadgeDto>>> GetUserBadgesAsync()
+    {
+        var response = await _httpClient.GetAsync("/api/v1/user/badges");
+        return await ApiResponse<List<BadgeDto>>.CreateAsync(response);
+    }
+
+    public async Task<ApiResponse<List<BadgeDto>>> AddBadgesToUserAsync(AddBadgesToUserViewModel model)
+    {
+        var response = await _httpClient.PostAsJsonAsync("/api/v1/user/badges", model);
+        return await ApiResponse<List<BadgeDto>>.CreateAsync(response);
+    }
+}
+
+public class ApiResponse<T>
+{
+    public T Data { get; set; }
+    public bool IsSuccessStatusCode { get; set; }
+    public int StatusCode { get; set; }
+    public string ReasonPhrase { get; set; }
+    public ContentResult ErrorContent { get; set; }
+
+    public static async Task<ApiResponse<T>> CreateAsync(HttpResponseMessage response)
+    {
+        var apiResponse = new ApiResponse<T>
+        {
+            IsSuccessStatusCode = response.IsSuccessStatusCode,
+            StatusCode = (int)response.StatusCode,
+            ReasonPhrase = response.ReasonPhrase
+        };
+
+        if (response.IsSuccessStatusCode)
+        {
+            apiResponse.Data = await response.Content.ReadFromJsonAsync<T>();
+        }
+        else
+        {
+            apiResponse.ErrorContent = await response.Content.ReadFromJsonAsync<ContentResult>();
+        }
+
+        return apiResponse;
+    }
+}

--- a/Models/AddBadgesToUserViewModel.cs
+++ b/Models/AddBadgesToUserViewModel.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+
+public class AddBadgesToUserViewModel
+{
+    public int UserId { get; set; }
+    public List<int> BadgeIds { get; set; }
+}

--- a/Tests/UserBadgesApiTests.cs
+++ b/Tests/UserBadgesApiTests.cs
@@ -1,0 +1,70 @@
+using NUnit.Framework;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using System.Net;
+
+[TestFixture]
+public class UserBadgesApiTests
+{
+    private UserBadgesApiClient _client;
+    private HttpClient _httpClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        _httpClient = new HttpClient();
+        _client = new UserBadgesApiClient(_httpClient);
+    }
+
+    [Test]
+    public async Task AT157_GetUserBadges_SuccessfulRetrieval()
+    {
+        // Arrange
+        // Assuming we have a valid authentication mechanism
+        // _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "validToken");
+
+        // Act
+        var response = await _client.GetUserBadgesAsync();
+
+        // Assert
+        response.IsSuccessStatusCode.Should().BeTrue();
+        response.StatusCode.Should().Be((int)HttpStatusCode.OK);
+        response.Data.Should().NotBeNull();
+        response.Data.Should().BeOfType<List<BadgeDto>>();
+        response.Data.Should().NotBeEmpty();
+
+        // Validate structure of BadgeDto
+        var firstBadge = response.Data[0];
+        firstBadge.Should().NotBeNull();
+        firstBadge.Id.Should().BeGreaterThan(0);
+        firstBadge.Name.Should().NotBeNullOrEmpty();
+        firstBadge.CreateDate.Should().NotBe(default(DateTime));
+        firstBadge.UpdateDate.Should().NotBe(default(DateTime));
+    }
+
+    [Test]
+    public async Task AT158_GetUserBadges_UnauthorizedAccess()
+    {
+        // Arrange
+        // Ensure no authentication token is set
+        _httpClient.DefaultRequestHeaders.Authorization = null;
+
+        // Act
+        var response = await _client.GetUserBadgesAsync();
+
+        // Assert
+        response.IsSuccessStatusCode.Should().BeFalse();
+        response.StatusCode.Should().Be((int)HttpStatusCode.Unauthorized);
+        response.Data.Should().BeNull();
+        response.ErrorContent.Should().NotBeNull();
+        response.ErrorContent.StatusCode.Should().Be((int)HttpStatusCode.Unauthorized);
+        response.ErrorContent.Content.Should().Contain("Unauthorized");
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        _httpClient.Dispose();
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes:

1. **DTO Model**: Added `AddBadgesToUserViewModel` in `Models/AddBadgesToUserViewModel.cs`
2. **API Client**: Added `UserBadgesApiClient` in `Clients/UserBadgesApiClient.cs`
3. **NUnit Tests**: Added tests for `/api/v1/user/badges` endpoint in `Tests/UserBadgesApiTests.cs`

These changes cover the following Jira issues:
- **AT-157**: [TC-/api/v1/user/badges GET - Validate successful retrieval of badges list for a user](https://taa-test-project.atlassian.net/browse/AT-157)
- **AT-158**: [TC-/api/v1/user/badges GET - Validate error response when accessing without authentication](https://taa-test-project.atlassian.net/browse/AT-158)